### PR TITLE
redshift: Create ingress security group role, update cross account permission [sc-25063]

### DIFF
--- a/rds-for-postgresql/provision.py
+++ b/rds-for-postgresql/provision.py
@@ -9,7 +9,7 @@ import psycopg2
 from psycopg2 import sql
 from aws_xray_sdk.core import xray_recorder
 from aws_xray_sdk.core import patch_all
-
+import os
 import hashlib
 
 logging.basicConfig(
@@ -18,8 +18,9 @@ logging.basicConfig(
     level=logging.INFO,
 )
 
-xray_recorder.configure(service='Select Star & AWS RDS for PostgreSQL integration')
-patch_all()
+if 'LAMBDA_TASK_ROOT' in os.environ:
+    xray_recorder.configure(service='Select Star & AWS RDS for PostgreSQL integration')
+    patch_all()
 
 USER_ACTIVITY = "enable_user_activity_logging"
 

--- a/redshift/SelectStarRedshift.json
+++ b/redshift/SelectStarRedshift.json
@@ -27,6 +27,26 @@
             "MinLength": "1",
             "Type": "String"
         },
+        "CidrIpPrimary": {
+            "Description": "The Select Star primary address range that will gain network access to the Redshift cluster. Do not change this.",
+            "Type": "String",
+            "Default": "3.23.108.85/32",
+            "AllowedValues": [
+                "3.23.108.85/32",
+                "3.20.56.105/32",
+                "0.0.0.0/0"
+            ]
+        },
+        "CidrIpSecondary": {
+            "Description": "The Select Star secondary address range that will gain network access to the Redshift cluster. Do not change this.",
+            "Type": "String",
+            "Default": "3.20.56.105/32",
+            "AllowedValues": [
+                "3.23.108.85/32",
+                "3.20.56.105/32",
+                "0.0.0.0/0"
+            ]
+        },
         "ConfigureS3Logging": {
             "Type": "String",
             "AllowedValues": [
@@ -72,7 +92,9 @@
                     },
                     "Parameters": [
                         "ExternalId",
-                        "IamPrincipal"
+                        "IamPrincipal",
+                        "CidrIpPrimary",
+                        "CidrIpSecondary"
                     ]
                 }
             ],
@@ -263,7 +285,8 @@
                                 "s3:ListMultipartUploadParts",
                                 "s3:GetObject",
                                 "s3:GetBucketLocation",
-                                "s3:GetObjectVersion"
+                                "s3:GetObjectVersion",
+                                "s3:ListBucket"
                             ],
                             "Resource": [
                                 {
@@ -504,6 +527,66 @@
                 },
                 "Prefix": {
                     "Fn::Sub": "arn:aws:redshift:${AWS::Region}:${AWS::AccountId}:dbname:${Cluster}/"
+                }
+            }
+        },
+        "InboundPrimaryRule": {
+            "Type": "AWS::EC2::SecurityGroupIngress",
+            "Properties": {
+                "IpProtocol": "tcp",
+                "Description": {
+                    "Fn::Sub": "Authorize primary Select Star address range to access Redshift cluster: ${Cluster}"
+                },
+                "FromPort": {
+                    "Fn::GetAtt": [
+                        "LambdaProvision",
+                        "RedshiftPort"
+                    ]
+                },
+                "ToPort": {
+                    "Fn::GetAtt": [
+                        "LambdaProvision",
+                        "RedshiftPort"
+                    ]
+                },
+                "CidrIp": {
+                    "Ref": "CidrIpPrimary"
+                },
+                "GroupId": {
+                    "Fn::GetAtt": [
+                        "LambdaProvision",
+                        "SecurityGroupId"
+                    ]
+                }
+            }
+        },
+        "InboundSecondaryRule": {
+            "Type": "AWS::EC2::SecurityGroupIngress",
+            "Properties": {
+                "IpProtocol": "tcp",
+                "Description": {
+                    "Fn::Sub": "Authorize secondary Select Star addresss range to access Redshift cluster ${Cluster}"
+                },
+                "FromPort": {
+                    "Fn::GetAtt": [
+                        "LambdaProvision",
+                        "RedshiftPort"
+                    ]
+                },
+                "ToPort": {
+                    "Fn::GetAtt": [
+                        "LambdaProvision",
+                        "RedshiftPort"
+                    ]
+                },
+                "CidrIp": {
+                    "Ref": "CidrIpSecondary"
+                },
+                "GroupId": {
+                    "Fn::GetAtt": [
+                        "LambdaProvision",
+                        "SecurityGroupId"
+                    ]
                 }
             }
         }


### PR DESCRIPTION
@podpio spotted that we need create ingress rule of security group to enable successful connection from Select Star to consumer Redshift cluster. It discovery configuration & create relevant ingress rule of security group.

We determined also that we require additional permission to list objects in AWS S3 bucket to download logs successfully.

Security group ingress rules creates successfully:

<img width="1214" alt="image" src="https://user-images.githubusercontent.com/99484706/172374785-af08cc75-deb1-4a4a-8c05-6635e41a4e6d.png">

<img width="1175" alt="image" src="https://user-images.githubusercontent.com/99484706/172374878-170215ac-b9ad-4fd9-9d3c-357cdfe5e0d1.png">

As a resource managed by CloudFormation it will be automatically deleted when the CloudFormation Stack is deleted.