### PR TITLE
redshift: Add permission redshift:DescribeClusters [sc-21098]

### DIFF
--- a/redshift/SelectStarRedshift.json
+++ b/redshift/SelectStarRedshift.json
@@ -204,6 +204,7 @@
                         {
                             "Effect": "Allow",
                             "Action": [
+                                "redshift:DescribeClusters",
                                 "redshift:DescribeLoggingStatus",
                                 "redshift:ListSchemas",
                                 "redshift:ListTables",


### PR DESCRIPTION
This permission is required to fetch endpoint:

<img width="904" alt="image" src="https://user-images.githubusercontent.com/99484706/172877737-aafb2562-5bf2-4b27-82fe-fd1c99cab112.png">
