### PR TITLE
Fix permission to download object on copy [sc-27583]

### DIFF
--- a/rds-for-postgresql/SelectStarRDS.json
+++ b/rds-for-postgresql/SelectStarRDS.json
@@ -319,6 +319,13 @@
                                 {
                                     "Effect": "Allow",
                                     "Action": [
+                                        "s3:GetObject"
+                                    ],
+                                    "Resource": "*"
+                                },
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
                                         "secretsmanager:GetResourcePolicy",
                                         "secretsmanager:GetSecretValue",
                                         "secretsmanager:DescribeSecret",

--- a/redshift/SelectStarRedshift.json
+++ b/redshift/SelectStarRedshift.json
@@ -457,6 +457,13 @@
                                             ]
                                         }
                                     ]
+                                },
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
+                                        "s3:GetObject"
+                                    ],
+                                    "Resource": "*"
                                 }
                             ]
                         }


### PR DESCRIPTION
In #17 we miss that `CopyFunction` requires permission to download a deployment package. It turns out that such permission is required even in the case of a public object.