### PR TITLE
RDS: Update permission for RDS, add e2e tests [sc-28655]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,18 +65,6 @@ workflows:
             - oidc
           requires:
             - test
-          name: deploy chart on testing
-          aws-role-arn: arn:aws:iam::591617137652:role/circleci-selectstar-cloudformation-templates
-          aws-bucket-name: select-star-dev-adam-cloudformation
-          filters: &filter-testing
-            tags:
-              only: /.*/
-
-      - deploy:
-          context:
-            - oidc
-          requires:
-            - test
           name: deploy chart on preview
           aws-role-arn: arn:aws:iam::672751098944:role/circleci-selectstar-cloudformation-templates
           aws-bucket-name: select-star-preview-cloudformation

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,18 +37,6 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           MATRIX_CONTEXT: ${{ toJson(matrix) }}
         if: failure() && github.ref == 'refs/heads/main'
-  deploy_testing:
-    needs: 
-    - test
-    name: Deploy to preview for testing
-    # deploy always
-    uses: ./.github/workflows/deploy.yml
-    secrets:
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-    with:
-      aws-account-id: "591617137652"
-      aws-region: us-east-2
-      aws-bucket-name: select-star-dev-adam-cloudformation
 
   deploy_production:
     needs:

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 .vscode
 **/package
 **/*.zip
+terraform.tfstate*
+.terraform

--- a/rds-for-postgresql/SelectStarRDS.json
+++ b/rds-for-postgresql/SelectStarRDS.json
@@ -279,14 +279,7 @@
                                         "rds:*",
                                         "rds-db:*"
                                     ],
-                                    "Resource": [
-                                        {
-                                            "Fn::Sub": "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:${ServerName}"
-                                        },
-                                        {
-                                            "Fn::Sub": "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:pg:*"
-                                        }
-                                    ]
+                                    "Resource": "*"
                                 },
                                 {
                                     "Effect": "Allow",

--- a/rds-for-postgresql/e2e/.terraform.lock.hcl
+++ b/rds-for-postgresql/e2e/.terraform.lock.hcl
@@ -1,0 +1,41 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "4.24.0"
+  constraints = ">= 2.70.0"
+  hashes = [
+    "h1:+wJiCQKLEgY8a1ILFbebLgFX6q2xPJVV9wWp7eU2dsI=",
+    "zh:3b58916e93cab4249bef6fcf6fb2ae3bbf0cb67a876e669205e1f785ffce88a4",
+    "zh:5a51329c4d91ecdc2879a7d4acbc1dfd521ca6cd9a64f0d6f8c01d99a23fc98d",
+    "zh:5c65414467db9b4bbf2f83fb1188543d1015514bab8a2336b38fcccb507fc7ca",
+    "zh:65fc1514f0f1a06463b70694add57589c31debba625d78e25a9434e521a7a290",
+    "zh:71b357f85d47cdb806df850b950193abae7ed14201edeba184be4c1672631f50",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a1a89a7fb35fa6160963dae13861033493bd5f3e6bc5fd18a0fd745a066378be",
+    "zh:a9482369470168f3830a4a688506426769e1beb09fbdae25633acc508c0a9457",
+    "zh:bf93cb9d15a822bbb0510d3333f763d3d117ca56da350a30ff769049c6851b4c",
+    "zh:c17a405fe50bb16947b189a30e2c6e5983105023fa0c45bb57fb5e63232b316d",
+    "zh:d0c2a0bec642444fd2eb1ecc13e5716bcfe30c80aae5622c8a5692b7af143a57",
+    "zh:dd469fa460f4ce8ebd6a107babf13b1aebee9b2e274f216155f62c23df67c228",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version = "3.3.2"
+  hashes = [
+    "h1:YChjos7Hrvr2KgTc9GzQ+de/QE2VLAeRJgxFemnCltU=",
+    "zh:038293aebfede983e45ee55c328e3fde82ae2e5719c9bd233c324cfacc437f9c",
+    "zh:07eaeab03a723d83ac1cc218f3a59fceb7bbf301b38e89a26807d1c93c81cef8",
+    "zh:427611a4ce9d856b1c73bea986d841a969e4c2799c8ac7c18798d0cc42b78d32",
+    "zh:49718d2da653c06a70ba81fd055e2b99dfd52dcb86820a6aeea620df22cd3b30",
+    "zh:5574828d90b19ab762604c6306337e6cd430e65868e13ef6ddb4e25ddb9ad4c0",
+    "zh:7222e16f7833199dabf1bc5401c56d708ec052b2a5870988bc89ff85b68a5388",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:b1b2d7d934784d2aee98b0f8f07a8ccfc0410de63493ae2bf2222c165becf938",
+    "zh:b8f85b6a20bd264fcd0814866f415f0a368d1123cd7879c8ebbf905d370babc8",
+    "zh:c3813133acc02bbebddf046d9942e8ba5c35fc99191e3eb057957dafc2929912",
+    "zh:e7a41dbc919d1de800689a81c240c27eec6b9395564630764ebb323ea82ac8a9",
+    "zh:ee6d23208449a8eaa6c4f203e33f5176fa795b4b9ecf32903dffe6e2574732c2",
+  ]
+}

--- a/rds-for-postgresql/e2e/README.md
+++ b/rds-for-postgresql/e2e/README.md
@@ -1,0 +1,31 @@
+# E2E tests for CloudFormation template for AWS for PostgreSQL integration
+
+These tests are intended to verify the E2E of the CloudFormation template. During their operation, the infrastructure is created and then the CloudFormation stack is created.
+
+## Requirements
+
+* Access to AWS account
+* Terraform pre-installed
+
+## Usage
+
+Initialize Terraform (eg. create state file):
+
+```bash
+terraform init
+```
+
+Starts tests (eg. create state file):
+
+```bash
+terraform apply
+```
+
+After testing, be sure to delete resources:
+
+```bash
+terraform destroy
+terraform destroy
+```
+
+If the removal of CloudFormation Stack fails, it is worth restarting the operation, because then the stack is deleted without the problematic resources (most likely due to the impossibility of correct `LambdaFunction` execution).

--- a/rds-for-postgresql/e2e/main.tf
+++ b/rds-for-postgresql/e2e/main.tf
@@ -1,0 +1,113 @@
+provider "aws" {
+  region = var.region
+
+  default_tags {
+    tags = {
+      Component = var.name
+      ManagedBy = "Terraform"
+    }
+  }
+}
+
+variable "region" {
+  default     = "us-east-2"
+  description = "AWS region"
+}
+
+variable "name" {
+  default = "test-e2e-cloudformation-rds-for-postgresql"
+  type    = string
+}
+
+resource "random_string" "random" {
+  length = 32
+  special = false
+}
+
+data "aws_availability_zones" "available" {}
+
+data "aws_caller_identity" "current" {}
+
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "3.14.2"
+
+  name                 = var.name
+  cidr                 = "10.0.0.0/16"
+  azs                  = data.aws_availability_zones.available.names
+  public_subnets       = ["10.0.4.0/24", "10.0.5.0/24", "10.0.6.0/24"]
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+}
+
+resource "aws_db_subnet_group" "subnet-group" {
+  name       = var.name
+  subnet_ids = module.vpc.public_subnets
+}
+
+resource "aws_security_group" "security-group" {
+  name   = var.name
+  vpc_id = module.vpc.vpc_id
+
+  ingress {
+    from_port   = 5432
+    to_port     = 5432
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 5432
+    to_port     = 5432
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+# resource "aws_db_parameter_group" "test-e2e-cloudformation" {
+#   name   = "test-e2e-cloudformation"
+#   family = "postgres13"
+
+#   parameter {
+#     name  = "log_connections"
+#     value = "1"
+#   }
+# }
+
+resource "aws_db_instance" "db-instance" {
+  identifier             = var.name
+  instance_class         = "db.t3.micro"
+  allocated_storage      = 5
+  engine                 = "postgres"
+  engine_version         = "14.2"
+  username               = "edu"
+  password               = random_string.random.result
+  db_subnet_group_name   = aws_db_subnet_group.subnet-group.name
+  vpc_security_group_ids = [aws_security_group.security-group.id]
+  #   parameter_group_name   = aws_db_parameter_group.test-e2e-cloudformation.name
+  publicly_accessible = true
+  skip_final_snapshot = true
+}
+
+resource "aws_cloudformation_stack" "stack" {
+  name = var.name
+
+  disable_rollback = true
+
+  parameters = {
+    ServerName              = aws_db_instance.db-instance.identifier
+    Schema                  = "*.*"
+    DbUser                  = aws_db_instance.db-instance.username
+    DbPassword              = aws_db_instance.db-instance.password
+    ProvisionAccessUserName = "selectstar"
+    ExternalId              = "X"
+    IamPrincipal            = data.aws_caller_identity.current.account_id
+    ConfigureLogging        = "true"
+    ConfigureLoggingRestart = "true"
+    CidrIpPrimary           = "3.23.108.85/32"
+    CidrIpSecondary         = "3.20.56.105/32"
+  }
+
+  capabilities = ["CAPABILITY_IAM"]
+  template_body = file("${path.module}/../SelectStarRDS.json")
+}


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change. -->

In case you need to create a parameters group for RDS, the operation may fail because we have not given ourselves the proper privileges. That PR extends permissions of `LambdaRole` to RDS to grant all actions and resources, as the code is controlled and known to the user and can be freely audited.

Example error message available in AWS CloudWatch:

```
An error occurred (AccessDenied) when calling the DescribeDBEngineVersions operation: User: arn:aws:sts::xxx:assumed-role/SelectStarPostgresIntegration-LambdaRole-11W021D3EH5EC/SelectStarPostgresIntegration-LambdaFunction-0OCO32p5JXnC is not authorized to perform: rds:DescribeDBEngineVersions because no identity-based policy allows the rds:DescribeDBEngineVersions action
```

## How to reproduce/test?

<!-- Please please provide links or steps which help to check your submission. You can also put any evidence "works for me" here. --> 

Follow README of newly added tests.

<img width="1552" alt="image" src="https://user-images.githubusercontent.com/99484706/182914971-7500a738-38d1-463b-a12b-5b523ac22b98.png">

## Type of change

-   [ ] Refactor (non-breaking change that improves codebase).
-   [ ] Bug fix (non-breaking change that fixes an issue).
-   [ ] New feature (non-breaking change that adds functionality).
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
-   [ ] Chore (none of the above, but still important)

## Related tickets

-   Story sc-28655

## Checklists

-   [ ] No backend changes needed.
-   [ ] All related backend changes are ready.
    -   [links to related PRs]
    
    