### PR TITLE
RDS: Enable support for replicas [sc-28655]

### DIFF
--- a/rds-for-postgresql/SelectStarRDS.json
+++ b/rds-for-postgresql/SelectStarRDS.json
@@ -499,7 +499,7 @@
             },
             "Description": "The ARN value of the Cross-Account Role with IAM read-only permissions. Add this ARN value to Select Star."
         },
-        "secretArn": {
+        "SecretArn": {
             "Value": {
                 "Ref": "DatabaseSecret"
             },

--- a/rds-for-postgresql/e2e/.terraform.lock.hcl
+++ b/rds-for-postgresql/e2e/.terraform.lock.hcl
@@ -2,22 +2,41 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "4.24.0"
-  constraints = ">= 2.70.0"
+  version     = "4.25.0"
+  constraints = ">= 3.63.0"
   hashes = [
-    "h1:+wJiCQKLEgY8a1ILFbebLgFX6q2xPJVV9wWp7eU2dsI=",
-    "zh:3b58916e93cab4249bef6fcf6fb2ae3bbf0cb67a876e669205e1f785ffce88a4",
-    "zh:5a51329c4d91ecdc2879a7d4acbc1dfd521ca6cd9a64f0d6f8c01d99a23fc98d",
-    "zh:5c65414467db9b4bbf2f83fb1188543d1015514bab8a2336b38fcccb507fc7ca",
-    "zh:65fc1514f0f1a06463b70694add57589c31debba625d78e25a9434e521a7a290",
-    "zh:71b357f85d47cdb806df850b950193abae7ed14201edeba184be4c1672631f50",
+    "h1:JyQAQ3YrE4utVAQsLGy1LjMbAzzRI/X2XsrY7CFBGxw=",
+    "zh:51fddc33f289108f60c2de78537f758ae913b2614187abfc3f560f9dd277bc1a",
+    "zh:5a2bfa0725a8941f12e775eb9c44582ec237a664321a740d8283e9b56452f2ad",
+    "zh:6ca73a9f11c2a9ff8f55433c00a12c1b69c22131251cb0698d32c682229b1233",
     "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
-    "zh:a1a89a7fb35fa6160963dae13861033493bd5f3e6bc5fd18a0fd745a066378be",
-    "zh:a9482369470168f3830a4a688506426769e1beb09fbdae25633acc508c0a9457",
-    "zh:bf93cb9d15a822bbb0510d3333f763d3d117ca56da350a30ff769049c6851b4c",
-    "zh:c17a405fe50bb16947b189a30e2c6e5983105023fa0c45bb57fb5e63232b316d",
-    "zh:d0c2a0bec642444fd2eb1ecc13e5716bcfe30c80aae5622c8a5692b7af143a57",
-    "zh:dd469fa460f4ce8ebd6a107babf13b1aebee9b2e274f216155f62c23df67c228",
+    "zh:aeafec22947a7be418adc3c6d1eddb719ed02b5e41b6e2cc9cbdca991e2140b8",
+    "zh:b043563789e32f6935bf51c3b4344482487c03cb084673f6181ce3443f956a3d",
+    "zh:b0693f4295d35ae6ce3656ee2294fd69eb732f601ba7d6eb28b7fded4471c3d2",
+    "zh:bccb9ec142aa11350a52142b71fd8f0332d36a94332207f45bd93ceb7297b922",
+    "zh:c353fd5060cf6d86e4505d0ade84a37f91d4d8774b17eaa1290a191d9da43729",
+    "zh:d07848da6940b2882b884fc24144741f7ce0442865c9833df26751c48429e11f",
+    "zh:d4feeb5c394ec9528d1633e2e2c133632d8d099f6c99654e2bbd2aa112b6a08e",
+    "zh:fb0a75edb943847354c759a665edb93fd7945b892be7d0511c6708785abf090c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/null" {
+  version = "3.1.1"
+  hashes = [
+    "h1:YvH6gTaQzGdNv+SKTZujU1O0bO+Pw6vJHOPhqgN8XNs=",
+    "zh:063466f41f1d9fd0dd93722840c1314f046d8760b1812fa67c34de0afcba5597",
+    "zh:08c058e367de6debdad35fc24d97131c7cf75103baec8279aba3506a08b53faf",
+    "zh:73ce6dff935150d6ddc6ac4a10071e02647d10175c173cfe5dca81f3d13d8afe",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:8fdd792a626413502e68c195f2097352bdc6a0df694f7df350ed784741eb587e",
+    "zh:976bbaf268cb497400fd5b3c774d218f3933271864345f18deebe4dcbfcd6afa",
+    "zh:b21b78ca581f98f4cdb7a366b03ae9db23a73dfa7df12c533d7c19b68e9e72e5",
+    "zh:b7fc0c1615dbdb1d6fd4abb9c7dc7da286631f7ca2299fb9cd4664258ccfbff4",
+    "zh:d1efc942b2c44345e0c29bc976594cb7278c38cfb8897b344669eafbc3cddf46",
+    "zh:e356c245b3cd9d4789bab010893566acace682d7db877e52d40fc4ca34a50924",
+    "zh:ea98802ba92fcfa8cf12cbce2e9e7ebe999afbf8ed47fa45fc847a098d89468b",
+    "zh:eff8872458806499889f6927b5d954560f3d74bf20b6043409edf94d26cd906f",
   ]
 }
 

--- a/rds-for-postgresql/e2e/README.md
+++ b/rds-for-postgresql/e2e/README.md
@@ -29,3 +29,10 @@ terraform destroy
 ```
 
 If the removal of CloudFormation Stack fails, it is worth restarting the operation, because then the stack is deleted without the problematic resources (most likely due to the impossibility of correct `LambdaFunction` execution).
+
+To force CloudFormation Stack to recreate use:
+
+```bash
+terraform taint random_id.master-identifier
+terraform taint random_id.replica-identifier
+```

--- a/rds-for-postgresql/e2e/main.tf
+++ b/rds-for-postgresql/e2e/main.tf
@@ -1,27 +1,11 @@
-provider "aws" {
-  region = var.region
-
-  default_tags {
-    tags = {
-      Component = var.name
-      ManagedBy = "Terraform"
-    }
-  }
-}
-
 variable "region" {
   default     = "us-east-2"
   description = "AWS region"
 }
 
 variable "name" {
-  default = "test-e2e-cloudformation-rds-for-postgresql"
+  default = "test-rds-for-postgresql"
   type    = string
-}
-
-resource "random_string" "random" {
-  length = 32
-  special = false
 }
 
 data "aws_availability_zones" "available" {}
@@ -55,6 +39,12 @@ resource "aws_security_group" "security-group" {
     protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
+  lifecycle {
+    # provision.py add a new ingress rules what we wanna ignore here
+    ignore_changes = [
+      ingress,
+    ]
+  }
 
   egress {
     from_port   = 5432
@@ -64,18 +54,43 @@ resource "aws_security_group" "security-group" {
   }
 }
 
-# resource "aws_db_parameter_group" "test-e2e-cloudformation" {
-#   name   = "test-e2e-cloudformation"
-#   family = "postgres13"
+// E2E setup for master
+resource "aws_db_parameter_group" "test-e2e-cloudformation" {
+  name   = "test-e2e-cloudformation"
+  family = "postgres14"
 
-#   parameter {
-#     name  = "log_connections"
-#     value = "1"
-#   }
-# }
+  parameter {
+    name  = "log_connections"
+    value = "1"
+  }
+}
 
-resource "aws_db_instance" "db-instance" {
-  identifier             = var.name
+resource "random_string" "random" {
+  length  = 32
+  special = false
+}
+
+resource "aws_s3_bucket" "cloudformation-bucket" {
+  bucket_prefix = "e2e-test"
+  acl           = "public-read"
+}
+
+resource "aws_s3_object" "cloudformation-object" {
+  bucket = aws_s3_bucket.cloudformation-bucket.id
+
+  key    = "SelectStarRDS.json"
+  source = "${path.module}/../SelectStarRDS.json"
+  acl    = "public-read"
+
+  etag = filemd5("${path.module}/../SelectStarRDS.json")
+}
+
+locals {
+  template_url = "https://${aws_s3_bucket.cloudformation-bucket.bucket_regional_domain_name}/${aws_s3_object.cloudformation-object.id}"
+}
+
+resource "aws_db_instance" "db-master" {
+  identifier             = "${var.name}-master"
   instance_class         = "db.t3.micro"
   allocated_storage      = 5
   engine                 = "postgres"
@@ -84,22 +99,39 @@ resource "aws_db_instance" "db-instance" {
   password               = random_string.random.result
   db_subnet_group_name   = aws_db_subnet_group.subnet-group.name
   vpc_security_group_ids = [aws_security_group.security-group.id]
-  #   parameter_group_name   = aws_db_parameter_group.test-e2e-cloudformation.name
-  publicly_accessible = true
-  skip_final_snapshot = true
+  publicly_accessible      = true
+  skip_final_snapshot      = true
+  delete_automated_backups = true
+  apply_immediately        = true
+  backup_retention_period  = 1
+
+  lifecycle {
+    # provision.py add a new ingress rules what we wanna ignore here to aovid rollback
+    ignore_changes = [
+      enabled_cloudwatch_logs_exports,
+    ]
+  }
+}
+resource "random_id" "master-identifier" {
+  keepers = {
+    identifier = aws_db_instance.db-master.identifier
+    etag       = aws_s3_object.cloudformation-object.etag
+  }
+
+  byte_length = 8
 }
 
-resource "aws_cloudformation_stack" "stack" {
-  name = var.name
+resource "aws_cloudformation_stack" "stack-master" {
+  name = "stack-${random_id.master-identifier.hex}-${aws_db_instance.db-master.identifier}"
 
   disable_rollback = true
 
   parameters = {
-    ServerName              = aws_db_instance.db-instance.identifier
+    ServerName              = aws_db_instance.db-master.identifier
     Schema                  = "*.*"
-    DbUser                  = aws_db_instance.db-instance.username
-    DbPassword              = aws_db_instance.db-instance.password
-    ProvisionAccessUserName = "selectstar"
+    DbUser                  = aws_db_instance.db-master.username
+    DbPassword              = random_string.random.result
+    ProvisionAccessUserName = "selectstar-${random_id.master-identifier.hex}"
     ExternalId              = "X"
     IamPrincipal            = data.aws_caller_identity.current.account_id
     ConfigureLogging        = "true"
@@ -109,5 +141,99 @@ resource "aws_cloudformation_stack" "stack" {
   }
 
   capabilities = ["CAPABILITY_IAM"]
-  template_body = file("${path.module}/../SelectStarRDS.json")
+  template_url = local.template_url
+}
+
+
+// E2E setup for replica
+resource "aws_db_instance" "db-replica" {
+  identifier               = "${var.name}-replica"
+  instance_class           = "db.t3.micro"
+  allocated_storage        = 5
+  vpc_security_group_ids   = [aws_security_group.security-group.id]
+  parameter_group_name     = aws_db_parameter_group.test-e2e-cloudformation.name
+  publicly_accessible      = true
+  skip_final_snapshot      = true
+  delete_automated_backups = true
+  backup_retention_period  = 1
+  apply_immediately        = true
+
+  replicate_source_db = aws_db_instance.db-master.id
+
+  lifecycle {
+    # provision.py add a new ingress rules what we wanna ignore here to aovid rollback
+    ignore_changes = [
+      enabled_cloudwatch_logs_exports,
+    ]
+  }
+}
+
+resource "random_id" "replica-identifier" {
+  keepers = {
+    identifier = aws_db_instance.db-replica.identifier
+    etag       = aws_s3_object.cloudformation-object.etag
+  }
+
+  byte_length = 8
+}
+
+resource "aws_cloudformation_stack" "stack-replica" {
+  name = "stack-${random_id.replica-identifier.hex}-${aws_db_instance.db-replica.identifier}"
+
+  disable_rollback = true
+
+  parameters = {
+    ServerName              = aws_db_instance.db-replica.identifier
+    Schema                  = "*.*"
+    DbUser                  = aws_db_instance.db-replica.username
+    DbPassword              = random_string.random.result
+    ProvisionAccessUserName = "selectstar-replica-${random_id.replica-identifier.hex}"
+    ExternalId              = "X"
+    IamPrincipal            = data.aws_caller_identity.current.account_id
+    ConfigureLogging        = "true"
+    ConfigureLoggingRestart = "true"
+    CidrIpPrimary           = "3.23.108.85/32"
+    CidrIpSecondary         = "3.20.56.105/32"
+  }
+
+  capabilities = ["CAPABILITY_IAM"]
+  template_url = local.template_url
+}
+
+## Validation
+data "aws_secretsmanager_secret_version" "master" {
+  secret_id = aws_cloudformation_stack.stack-master.outputs.SecretArn
+}
+data "aws_secretsmanager_secret_version" "replica" {
+  secret_id = aws_cloudformation_stack.stack-replica.outputs.SecretArn
+}
+locals {
+  master_username  = jsondecode(data.aws_secretsmanager_secret_version.master.secret_string)["username"]
+  master_password  = jsondecode(data.aws_secretsmanager_secret_version.master.secret_string)["password"]
+  replica_username = jsondecode(data.aws_secretsmanager_secret_version.replica.secret_string)["username"]
+  replica_password = jsondecode(data.aws_secretsmanager_secret_version.replica.secret_string)["password"]
+}
+
+resource "null_resource" "connect-psql-master" {
+  provisioner "local-exec" {
+    command = "psql -c 'select 1'"
+    environment = {
+      PGPASSWORD = local.master_password
+      PGUSER     = local.master_username
+      PGDATABASE = "postgres"
+      PGHOST     = aws_db_instance.db-master.address
+    }
+  }
+}
+
+resource "null_resource" "connect-psql-replica" {
+  provisioner "local-exec" {
+    command = "psql -c 'select 1'"
+    environment = {
+      PGPASSWORD = local.replica_password
+      PGUSER     = local.replica_username
+      PGDATABASE = "postgres"
+      PGHOST     = aws_db_instance.db-replica.address
+    }
+  }
 }

--- a/rds-for-postgresql/e2e/providers.tf
+++ b/rds-for-postgresql/e2e/providers.tf
@@ -1,0 +1,11 @@
+provider "aws" {
+  region              = var.region
+  allowed_account_ids = ["792169733636"]
+
+  default_tags {
+    tags = {
+      Component = var.name
+      ManagedBy = "Terraform"
+    }
+  }
+}


### PR DESCRIPTION
That PR introduces support to provision AWS RDS for PostgreSQL instance replicas.

There have been also introducing e2e tests for replicas:

* setup a new RDS instance
* setup a new replica of the RDS instance
* setup integration to RDS instance
* setup integration to replica
* retrieve secret and attempt to RDS instance and replica
