### PR TITLE
Add reporting to Sentry any CloudFormation errors [sc-29406]

### DIFF
--- a/rds-for-postgresql/SelectStarRDS.json
+++ b/rds-for-postgresql/SelectStarRDS.json
@@ -73,6 +73,11 @@
                 "3.23.108.85/32",
                 "3.20.56.105/32"
             ]
+        },
+        "SentryDsn": {
+            "Description": "URL for reporting any errors in provisioning execution. Don't change it unless you really know what you are doing.",
+            "Type": "String",
+            "Default": "https://14d65555628a4b6f84fcb83ef1511778@o407979.ingest.sentry.io/6639248"
         }
     },
     "Metadata": {
@@ -107,7 +112,8 @@
                         "ExternalId",
                         "IamPrincipal",
                         "CidrIpPrimary",
-                        "CidrIpSecondary"
+                        "CidrIpSecondary",
+                        "SentryDsn"
                     ]
                 }
             ],
@@ -394,6 +400,13 @@
                         "LambdaCopy",
                         "Copy"
                     ]
+                },
+                "Environment": {
+                    "Variables": {
+                        "SENTRY_DSN": {
+                            "Ref": "SentryDsn"
+                        }
+                    }
                 },
                 "Role": {
                     "Fn::GetAtt": [

--- a/rds-for-postgresql/provision.py
+++ b/rds-for-postgresql/provision.py
@@ -597,8 +597,7 @@ def handler(event, context):
                 reason="Create complete",
             )
     except DataException as e:
-        sentry_sdk.capture_exception(e)
-        logger.error(e)
+        logger.exception("Operation failed and custom error message reported")
         return cfnresponse.send(
             event,
             context,
@@ -609,8 +608,7 @@ def handler(event, context):
             ),
         )
     except Exception as e:
-        sentry_sdk.capture_exception(e)
-        logging.error(e, exc_info=True)
+        logger.exception("Unexpected failure")
         return cfnresponse.send(
             event,
             context,

--- a/rds-for-postgresql/requirements.txt
+++ b/rds-for-postgresql/requirements.txt
@@ -1,3 +1,4 @@
 aws-psycopg2==1.2.1
 aws-xray-sdk==2.9.0
 httpx==0.23.0
+sentry-sdk==1.9.3

--- a/redshift/SelectStarRedshift.json
+++ b/redshift/SelectStarRedshift.json
@@ -67,6 +67,11 @@
                 "false"
             ],
             "Description": "If true and logging changes made then the Redshift cluster can be restarted to apply changes. It is recommended to set the value \"true\"."
+        },
+        "SentryDsn": {
+            "Description": "URL for reporting any errors in provisioning execution. Don't change it unless you really know what you are doing.",
+            "Type": "String",
+            "Default": "https://14d65555628a4b6f84fcb83ef1511778@o407979.ingest.sentry.io/6639248"
         }
     },
     "Metadata": {
@@ -485,6 +490,13 @@
                         "Copy"
                     ]
                 },
+                "Environment": {
+                    "Variables": {
+                        "SENTRY_DSN": {
+                            "Ref": "SentryDsn"
+                        }
+                    }
+                },
                 "Handler": "provision.handler",
                 "Role": {
                     "Fn::GetAtt": [
@@ -564,6 +576,13 @@
                         "LambdaRole",
                         "Arn"
                     ]
+                },
+                "Environment": {
+                    "Variables": {
+                        "SENTRY_DSN": {
+                            "Ref": "SentryDsn"
+                        }
+                    }
                 },
                 "Runtime": "python3.9",
                 "TracingConfig": {

--- a/redshift/requirements.txt
+++ b/redshift/requirements.txt
@@ -1,1 +1,2 @@
 aws-xray-sdk==2.9.0
+sentry-sdk==1.9.3

--- a/redshift/transform.py
+++ b/redshift/transform.py
@@ -1,7 +1,8 @@
 import json
 import logging
 import cfnresponse
-import boto3
+import os
+import sentry_sdk
 
 logging.basicConfig(
     format="%(asctime)s,%(msecs)d %(levelname)-8s [%(filename)s:%(lineno)d] %(message)s",
@@ -11,6 +12,13 @@ logging.basicConfig(
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
+
+if "SENTRY_DSN" in os.environ:
+    sentry_sdk.init(
+        dsn=os.environ["SENTRY_DSN"],
+        traces_sample_rate=0.0,
+    )
+    logger.info("Sentry DSN reporting initialized")
 
 
 def handler(event, context):
@@ -32,6 +40,7 @@ def handler(event, context):
                 reason="Create complete",
             )
     except Exception as e:
+        sentry_sdk.capture_exception(e)
         logging.error(e)
         return cfnresponse.send(
             event,

--- a/redshift/transform.py
+++ b/redshift/transform.py
@@ -40,8 +40,7 @@ def handler(event, context):
                 reason="Create complete",
             )
     except Exception as e:
-        sentry_sdk.capture_exception(e)
-        logging.error(e)
+        logger.exception("Unexpected failure")
         return cfnresponse.send(
             event,
             context,


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change. -->

Introduces reporting errors in AWS CloudFormation to Sentry.

Initially - in order to protect consumer privacy - we did not introduce any exception reporting to us. However, this has proven to be too costly and time-consuming in terms of user support, so we need to automate reporting.

For privacy-sensitive consumers, they can configure the `sentryDsn` parameter to `http://localhost/` or otherwise send it to `/dev/null`.

## How to reproduce/test?

<!-- Please please provide links or steps which help to check your submission. You can also put any evidence "works for me" here. --> 

You can deploy that CloudFormation stack and use eg. wrong username for provisioning. 

I tested that in that way and after a few minutes there is a new issue registered:

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/99484706/184038813-d671dd7f-e5da-4e8b-8d35-d6d42d873706.png">

## Type of change

-   [ ] Refactor (non-breaking change that improves codebase).
-   [ ] Bug fix (non-breaking change that fixes an issue).
-   [ ] New feature (non-breaking change that adds functionality).
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
-   [ ] Chore (none of the above, but still important)

## Related tickets

-   Story sc-29406

## Checklists

-   [ ] No backend changes needed.
-   [ ] All related backend changes are ready.
    -   [links to related PRs]
