### PR TITLE
RDS: Fix typing exception [sc-28655]

### DIFF
--- a/rds-for-postgresql/SelectStarRDS.json
+++ b/rds-for-postgresql/SelectStarRDS.json
@@ -393,7 +393,7 @@
                         "Arn"
                     ]
                 },
-                "Runtime": "python3.8",
+                "Runtime": "python3.9",
                 "TracingConfig": {
                     "Mode": "Active"
                 }


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change. -->

We should use Python 3.9 for AWS Lambda ( https://github.com/selectstar/cloudformation-templates/search?q=%22python3.9%22 ). We use that everywhere, but we omit that in one instance.

Python 3.9 is the latest available runtime for Python ( https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html ) at that moment.

We have the following error without that:

```
[ERROR] TypeError: 'type' object is not subscriptable
Traceback (most recent call last):
  File "/var/lang/lib/python3.8/imp.py", line 234, in load_module
    return load_source(name, filename, file)
  File "/var/lang/lib/python3.8/imp.py", line 171, in load_source
    module = _load(spec)
  File "<frozen importlib._bootstrap>", line 702, in _load
  File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 843, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/var/task/provision.py", line 310, in <module>
    def create_ingress_rules(instance) -> tuple[str, Sequence[str]]:
```

## How to reproduce/test?

<!-- Please please provide links or steps which help to check your submission. You can also put any evidence "works for me" here. --> 

Deploy CloudFormation stack. It should finish pretty quickly.

## Type of change

-   [ ] Refactor (non-breaking change that improves codebase).
-   [ ] Bug fix (non-breaking change that fixes an issue).
-   [ ] New feature (non-breaking change that adds functionality).
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
-   [ ] Chore (none of the above, but still important)

## Related tickets

-   Story sc-28655

## Checklists

-   [ ] No backend changes needed.
-   [ ] All related backend changes are ready.
    -   [links to related PRs]
