### PR TITLE
Add suffix to custom parameter group in Redshift [sc-38653]

### DIFF
--- a/redshift/e2e/.terraform.lock.hcl
+++ b/redshift/e2e/.terraform.lock.hcl
@@ -40,25 +40,6 @@ provider "registry.terraform.io/hashicorp/http" {
   ]
 }
 
-provider "registry.terraform.io/hashicorp/null" {
-  version = "3.1.1"
-  hashes = [
-    "h1:YvH6gTaQzGdNv+SKTZujU1O0bO+Pw6vJHOPhqgN8XNs=",
-    "zh:063466f41f1d9fd0dd93722840c1314f046d8760b1812fa67c34de0afcba5597",
-    "zh:08c058e367de6debdad35fc24d97131c7cf75103baec8279aba3506a08b53faf",
-    "zh:73ce6dff935150d6ddc6ac4a10071e02647d10175c173cfe5dca81f3d13d8afe",
-    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:8fdd792a626413502e68c195f2097352bdc6a0df694f7df350ed784741eb587e",
-    "zh:976bbaf268cb497400fd5b3c774d218f3933271864345f18deebe4dcbfcd6afa",
-    "zh:b21b78ca581f98f4cdb7a366b03ae9db23a73dfa7df12c533d7c19b68e9e72e5",
-    "zh:b7fc0c1615dbdb1d6fd4abb9c7dc7da286631f7ca2299fb9cd4664258ccfbff4",
-    "zh:d1efc942b2c44345e0c29bc976594cb7278c38cfb8897b344669eafbc3cddf46",
-    "zh:e356c245b3cd9d4789bab010893566acace682d7db877e52d40fc4ca34a50924",
-    "zh:ea98802ba92fcfa8cf12cbce2e9e7ebe999afbf8ed47fa45fc847a098d89468b",
-    "zh:eff8872458806499889f6927b5d954560f3d74bf20b6043409edf94d26cd906f",
-  ]
-}
-
 provider "registry.terraform.io/hashicorp/random" {
   version = "3.3.2"
   hashes = [

--- a/redshift/provision.py
+++ b/redshift/provision.py
@@ -197,6 +197,28 @@ def ensure_logging_enabled(cluster, configureS3Logging, bucket):
     return logging_bucket
 
 
+def create_cluster_parameter_group(parameter_group, prefix):
+    suffix = ""
+    for i in range(10):
+        try:
+            name = f"{prefix}{suffix}"
+            suffix = f"-{i}"
+            logger.info("Creating new parameter group with name: %s", name)
+            redshift_client.create_cluster_parameter_group(
+                ParameterGroupName=name,
+                ParameterGroupFamily=parameter_group["ParameterGroupFamily"],
+                Description="Created by CloudFormation on provisioning Select Star",
+            )
+            return name
+        except redshift_client.exceptions.ClusterParameterGroupAlreadyExistsFault as err:
+            logger.warn(f"API call failed ({err}); continue with new suffix...")
+            continue
+    raise DataException(
+        "Unable to create new cluster paramter group. Failed to find a new unique name. "
+        + "Create and add custom parameter group to the Redshift cluster manually and try again."
+    )
+
+
 @retry_aws(codes=["InvalidClusterParameterGroupState"])
 def ensure_custom_parameter_group(cluster, configureS3Logging):
     cluster_description = redshift_client.describe_clusters(ClusterIdentifier=cluster)[
@@ -215,11 +237,8 @@ def ensure_custom_parameter_group(cluster, configureS3Logging):
         parameter_group = redshift_client.describe_cluster_parameter_groups(
             ParameterGroupName=parameter_group_name
         )["ParameterGroups"][0]
-        custom_parameter_group = f"redshift-custom-{cluster}"
-        redshift_client.create_cluster_parameter_group(
-            ParameterGroupName=custom_parameter_group,
-            ParameterGroupFamily=parameter_group["ParameterGroupFamily"],
-            Description="Created by CloudFormation on provisioning Select Star",
+        custom_parameter_group = create_cluster_parameter_group(
+            parameter_group=parameter_group, prefix=f"redshift-custom-{cluster}"
         )
         logging.info("Custom parameter group created: %s", custom_parameter_group)
         redshift_client.modify_cluster(


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change. -->

During review #30 I had error:

```
timestamp,message
1672976677239,"[INFO]	2023-01-06T03:44:37.239Z		Sentry DSN reporting initialized
"
1672976677242,"START RequestId: 32d521c8-beca-4270-b495-7893c5b080d1 Version: $LATEST
"
1672976677242,"[INFO]	2023-01-06T03:44:37.242Z	32d521c8-beca-4270-b495-7893c5b080d1	{""RequestType"": ""Create"", ""ServiceToken"": ""arn:aws:lambda:eu-central-1:792169733636:function:stack-41ba30e45d28c5c3-tes-LambdaProvisionFunction-IoPiKU1hCuXX"", ""ResponseURL"": ""https://cloudformation-custom-resource-response-eucentral1.s3.eu-central-1.amazonaws.com/arn%3Aaws%3Acloudformation%3Aeu-central-1%3A792169733636%3Astack/stack-41ba30e45d28c5c3-test-e2e-cloudformation/3cf84620-8d74-11ed-a198-02ea3c611334%7CLambdaProvision%7C49ad2034-b694-4a0a-a2e9-0903111075e1?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20230106T034436Z&X-Amz-SignedHeaders=host&X-Amz-Expires=7200&X-Amz-Credential=AKIAYYGVRKE7HVD63OFC%2F20230106%2Feu-central-1%2Fs3%2Faws4_request&X-Amz-Signature=fb138e49108e9d9ab05433dc99e53a6bafb7f013a919c45533ea2f9bbcb3422b"", ""StackId"": ""arn:aws:cloudformation:eu-central-1:792169733636:stack/stack-41ba30e45d28c5c3-test-e2e-cloudformation/3cf84620-8d74-11ed-a198-02ea3c611334"", ""RequestId"": ""49ad2034-b694-4a0a-a2e9-0903111075e1"", ""LogicalResourceId"": ""LambdaProvision"", ""ResourceType"": ""Custom::LambdaProvision"", ""ResourceProperties"": {""ServiceToken"": ""arn:aws:lambda:eu-central-1:792169733636:function:stack-41ba30e45d28c5c3-tes-LambdaProvisionFunction-IoPiKU1hCuXX"", ""ConfigureS3LoggingRestart"": ""true"", ""Grant"": [""*""], ""ConfigureS3Logging"": ""true"", ""Bucket"": ""stack-41ba30e45d28c5c3-test-e2e-clo-loggingbucket-ycs3o5tves5j"", ""RedshiftRole"": ""arn:aws:iam::792169733636:role/stack-41ba30e45d28c5c3-test-e2e-c-CrossAccountRole-ET96ASWHHI7B"", ""Cluster"": ""test-e2e-cloudformation"", ""Region"": ""eu-central-1"", ""Db"": ""mydb"", ""DbUser"": ""root""}}
"
1672976678433,"[INFO]	2023-01-06T03:44:38.433Z	32d521c8-beca-4270-b495-7893c5b080d1	Resolved '*' in grant to: ['dev', 'mydb']
"
1672976740396,"[ERROR]	2023-01-06T03:45:40.396Z	32d521c8-beca-4270-b495-7893c5b080d1	Unexpected failure
Traceback (most recent call last):
  File ""/var/task/provision.py"", line 376, in handler
    ensure_custom_parameter_group(cluster, configureS3Logging)
  File ""/var/task/provision.py"", line 66, in inner
    raise err
  File ""/var/task/provision.py"", line 57, in inner
    return fn(*args, **kwargs)
  File ""/var/task/provision.py"", line 220, in ensure_custom_parameter_group
    redshift_client.create_cluster_parameter_group(
  File ""/var/task/botocore/client.py"", line 508, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File ""/var/task/wrapt/wrappers.py"", line 644, in __call__
    return self._self_wrapper(self.__wrapped__, self._self_instance,
  File ""/var/task/aws_xray_sdk/ext/botocore/patch.py"", line 38, in _xray_traced_botocore
    return xray_recorder.record_subsegment(
  File ""/var/task/aws_xray_sdk/core/recorder.py"", line 435, in record_subsegment
    return_value = wrapped(*args, **kwargs)
  File ""/var/task/botocore/client.py"", line 911, in _make_api_call
    raise error_class(parsed_response, operation_name)
botocore.errorfactory.ClusterParameterGroupAlreadyExistsFault: An error occurred (ClusterParameterGroupAlreadyExists) when calling the CreateClusterParameterGroup operation: Parameter group redshift-custom-test-e2e-cloudformation already exists"
1672976741837,"https://cloudformation-custom-resource-response-eucentral1.s3.eu-central-1.amazonaws.com/arn%3Aaws%3Acloudformation%3Aeu-central-1%3A792169733636%3Astack/stack-41ba30e45d28c5c3-test-e2e-cloudformation/3cf84620-8d74-11ed-a198-02ea3c611334%7CLambdaProvision%7C49ad2034-b694-4a0a-a2e9-0903111075e1?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20230106T034436Z&X-Amz-SignedHeaders=host&X-Amz-Expires=7200&X-Amz-Credential=AKIAYYGVRKE7HVD63OFC%2F20230106%2Feu-central-1%2Fs3%2Faws4_request&X-Amz-Signature=fb138e49108e9d9ab05433dc99e53a6bafb7f013a919c45533ea2f9bbcb3422b
"
1672976741837,"Response body:
"
1672976741837,"{""Status"": ""FAILED"", ""Reason"": ""Something failed. See the details in CloudWatch Log Stream: 2023/01/06/[$LATEST]e5a34b05abd3409ca6279a5a084f5358"", ""PhysicalResourceId"": ""2023/01/06/[$LATEST]e5a34b05abd3409ca6279a5a084f5358"", ""StackId"": ""arn:aws:cloudformation:eu-central-1:792169733636:stack/stack-41ba30e45d28c5c3-test-e2e-cloudformation/3cf84620-8d74-11ed-a198-02ea3c611334"", ""RequestId"": ""49ad2034-b694-4a0a-a2e9-0903111075e1"", ""LogicalResourceId"": ""LambdaProvision"", ""NoEcho"": false, ""Data"": {}}
"
1672976742387,"Status code: 200
"
1672976742389,"END RequestId: 32d521c8-beca-4270-b495-7893c5b080d1
"
1672976742389,"REPORT RequestId: 32d521c8-beca-4270-b495-7893c5b080d1	Duration: 65147.77 ms	Billed Duration: 65148 ms	Memory Size: 128 MB	Max Memory Used: 83 MB	Init Duration: 753.32 ms	
XRAY TraceId: 1-63b79924-54e78c7103decaf92898288d	SegmentId: 6de9a4c67e30e215	Sampled: true	
"
```

That PR fixes that issue by adding suffixing to custom parameter group:

```
timestamp,message
1672979142889,"[INFO]	2023-01-06T04:25:42.889Z		Sentry DSN reporting initialized
"
1672979142892,"START RequestId: afebb0f3-e3e5-47f0-b633-4838efb0c18e Version: $LATEST
"
1672979142892,"[INFO]	2023-01-06T04:25:42.892Z	afebb0f3-e3e5-47f0-b633-4838efb0c18e	{""RequestType"": ""Create"", ""ServiceToken"": ""arn:aws:lambda:eu-central-1:792169733636:function:stack-41ba30e45d28c5c3-tes-LambdaProvisionFunction-2nGOKonESwAP"", ""ResponseURL"": ""https://cloudformation-custom-resource-response-eucentral1.s3.eu-central-1.amazonaws.com/arn%3Aaws%3Acloudformation%3Aeu-central-1%3A792169733636%3Astack/stack-41ba30e45d28c5c3-test-e2e-cloudformation/fcea82e0-8d79-11ed-84de-061989515ff8%7CLambdaProvision%7C91c7e133-b38b-4240-9e9e-f4d6693a076a?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20230106T042541Z&X-Amz-SignedHeaders=host&X-Amz-Expires=7200&X-Amz-Credential=AKIAYYGVRKE7HVD63OFC%2F20230106%2Feu-central-1%2Fs3%2Faws4_request&X-Amz-Signature=da235534a54b9647ce730f73c5be7145c4ca982a8eabaf611726069f6796cf95"", ""StackId"": ""arn:aws:cloudformation:eu-central-1:792169733636:stack/stack-41ba30e45d28c5c3-test-e2e-cloudformation/fcea82e0-8d79-11ed-84de-061989515ff8"", ""RequestId"": ""91c7e133-b38b-4240-9e9e-f4d6693a076a"", ""LogicalResourceId"": ""LambdaProvision"", ""ResourceType"": ""Custom::LambdaProvision"", ""ResourceProperties"": {""ServiceToken"": ""arn:aws:lambda:eu-central-1:792169733636:function:stack-41ba30e45d28c5c3-tes-LambdaProvisionFunction-2nGOKonESwAP"", ""ConfigureS3LoggingRestart"": ""true"", ""Grant"": [""*""], ""ConfigureS3Logging"": ""true"", ""Bucket"": ""stack-41ba30e45d28c5c3-test-e2e-clo-loggingbucket-1hf2nfcennqa3"", ""RedshiftRole"": ""arn:aws:iam::792169733636:role/stack-41ba30e45d28c5c3-test-e2e-c-CrossAccountRole-9KP6B7TKJ7DW"", ""Cluster"": ""test-e2e-cloudformation"", ""Region"": ""eu-central-1"", ""Db"": ""mydb"", ""DbUser"": ""root""}}
"
1672979143238,"[INFO]	2023-01-06T04:25:43.217Z	afebb0f3-e3e5-47f0-b633-4838efb0c18e	Cluster status is 'available'. 
"
1672979143239,"[INFO]	2023-01-06T04:25:43.239Z	afebb0f3-e3e5-47f0-b633-4838efb0c18e	Publicly accessible status is 'True'. 
"
1672979143899,"[INFO]	2023-01-06T04:25:43.898Z	afebb0f3-e3e5-47f0-b633-4838efb0c18e	Resolved '*' in grant to: ['dev', 'mydb']
"
1672979143978,"[INFO]	2023-01-06T04:25:43.968Z	afebb0f3-e3e5-47f0-b633-4838efb0c18e	Determined security group ID: sg-0adee57443af17522
"
1672979143979,"[INFO]	2023-01-06T04:25:43.979Z	afebb0f3-e3e5-47f0-b633-4838efb0c18e	Determined endpoint port: 5439
"
1672979143979,"[INFO]	2023-01-06T04:25:43.979Z	afebb0f3-e3e5-47f0-b633-4838efb0c18e	Ćluster validated successfully
"
1672979144048,"[INFO]	2023-01-06T04:25:44.048Z	afebb0f3-e3e5-47f0-b633-4838efb0c18e	Add IAM role to cluster required.
"
1672979204617,"[INFO]	2023-01-06T04:26:44.617Z	afebb0f3-e3e5-47f0-b633-4838efb0c18e	IAM role configured successfully
"
1672979204681,"[INFO]	2023-01-06T04:26:44.680Z	afebb0f3-e3e5-47f0-b633-4838efb0c18e	Logging status: {'LoggingEnabled': True, 'BucketName': 'stack-41ba30e45d28c5c3-test-e2e-clo-loggingbucket-ycs3o5tves5j', 'S3KeyPrefix': 'redshift-logs/test-e2e-cloudformation/', 'LastSuccessfulDeliveryTime': datetime.datetime(2023, 1, 6, 3, 45, 47, 495000, tzinfo=tzlocal()), 'LastFailureTime': datetime.datetime(2023, 1, 6, 4, 26, 22, 286000, tzinfo=tzlocal()), 'LastFailureMessage': 'Unable to deliver the logs to your chosen bucket stack-41ba30e45d28c5c3-test-e2e-clo-loggingbucket-ycs3o5tves5j. Please check that the bucket has the right IAM policies as mentioned in our docs.', 'ResponseMetadata': {'RequestId': 'b179d697-8920-4dc5-8620-a8de78c084b7', 'HTTPStatusCode': 200, 'HTTPHeaders': {'x-amzn-requestid': 'b179d697-8920-4dc5-8620-a8de78c084b7', 'content-type': 'text/xml', 'content-length': '944', 'date': 'Fri, 06 Jan 2023 04:26:44 GMT'}, 'RetryAttempts': 0}}
"
1672979204681,"[INFO]	2023-01-06T04:26:44.681Z	afebb0f3-e3e5-47f0-b633-4838efb0c18e	S3 logging configured successfully
"
1672979204750,"[INFO]	2023-01-06T04:26:44.750Z	afebb0f3-e3e5-47f0-b633-4838efb0c18e	Current parameter group name: default.redshift-1.0
"
1672979204750,"[INFO]	2023-01-06T04:26:44.750Z	afebb0f3-e3e5-47f0-b633-4838efb0c18e	Create a new parameter group required.
"
1672979204803,"[INFO]	2023-01-06T04:26:44.803Z	afebb0f3-e3e5-47f0-b633-4838efb0c18e	Creating new parameter group with name: redshift-custom-test-e2e-cloudformation
"
1672979204960,"[WARNING]	2023-01-06T04:26:44.960Z	afebb0f3-e3e5-47f0-b633-4838efb0c18e	API call failed (An error occurred (ClusterParameterGroupAlreadyExists) when calling the CreateClusterParameterGroup operation: Parameter group redshift-custom-test-e2e-cloudformation already exists); continue with new suffix...
"
1672979204960,"[INFO]	2023-01-06T04:26:44.960Z	afebb0f3-e3e5-47f0-b633-4838efb0c18e	Creating new parameter group with name: redshift-custom-test-e2e-cloudformation-0
"
1672979205157,"[WARNING]	2023-01-06T04:26:45.157Z	afebb0f3-e3e5-47f0-b633-4838efb0c18e	API call failed (An error occurred (ClusterParameterGroupAlreadyExists) when calling the CreateClusterParameterGroup operation: Parameter group redshift-custom-test-e2e-cloudformation-0 already exists); continue with new suffix...
"
1672979205157,"[INFO]	2023-01-06T04:26:45.157Z	afebb0f3-e3e5-47f0-b633-4838efb0c18e	Creating new parameter group with name: redshift-custom-test-e2e-cloudformation-1
"
1672979205356,"[INFO]	2023-01-06T04:26:45.356Z	afebb0f3-e3e5-47f0-b633-4838efb0c18e	Custom parameter group created: redshift-custom-test-e2e-cloudformation-1
"
1672979205450,"[INFO]	2023-01-06T04:26:45.450Z	afebb0f3-e3e5-47f0-b633-4838efb0c18e	Custom parameter set for cluster: redshift-custom-test-e2e-cloudformation-1
"
1672979205548,"[INFO]	2023-01-06T04:26:45.548Z	afebb0f3-e3e5-47f0-b633-4838efb0c18e	Ensured a custom parameter group
"
1672979205616,"[INFO]	2023-01-06T04:26:45.616Z	afebb0f3-e3e5-47f0-b633-4838efb0c18e	Parameter group: redshift-custom-test-e2e-cloudformation-1
"
1672979206755,"[WARNING]	2023-01-06T04:26:46.755Z	afebb0f3-e3e5-47f0-b633-4838efb0c18e	API call failed (An error occurred (InvalidClusterParameterGroupState) when calling the ModifyClusterParameterGroup operation: There is a modify-parameter-group task in progress , please try again later. ); backing off and retrying...
"
1672979206956,"[INFO]	2023-01-06T04:26:46.956Z	afebb0f3-e3e5-47f0-b633-4838efb0c18e	Parameter group: redshift-custom-test-e2e-cloudformation-1
"
1672979209043,"[WARNING]	2023-01-06T04:26:49.043Z	afebb0f3-e3e5-47f0-b633-4838efb0c18e	API call failed (An error occurred (InvalidClusterParameterGroupState) when calling the ModifyClusterParameterGroup operation: There is a modify-parameter-group task in progress , please try again later. ); backing off and retrying...
"
1672979209247,"[INFO]	2023-01-06T04:26:49.247Z	afebb0f3-e3e5-47f0-b633-4838efb0c18e	Parameter group: redshift-custom-test-e2e-cloudformation-1
"
1672979213345,"[WARNING]	2023-01-06T04:26:53.345Z	afebb0f3-e3e5-47f0-b633-4838efb0c18e	API call failed (An error occurred (InvalidClusterParameterGroupState) when calling the ModifyClusterParameterGroup operation: There is a modify-parameter-group task in progress , please try again later. ); backing off and retrying...
"
1672979213559,"[INFO]	2023-01-06T04:26:53.559Z	afebb0f3-e3e5-47f0-b633-4838efb0c18e	Parameter group: redshift-custom-test-e2e-cloudformation-1
"
1672979221666,"[WARNING]	2023-01-06T04:27:01.666Z	afebb0f3-e3e5-47f0-b633-4838efb0c18e	API call failed (An error occurred (InvalidClusterParameterGroupState) when calling the ModifyClusterParameterGroup operation: There is a modify-parameter-group task in progress , please try again later. ); backing off and retrying...
"
1672979221941,"[INFO]	2023-01-06T04:27:01.941Z	afebb0f3-e3e5-47f0-b633-4838efb0c18e	Parameter group: redshift-custom-test-e2e-cloudformation-1
"
1672979238057,"[WARNING]	2023-01-06T04:27:18.057Z	afebb0f3-e3e5-47f0-b633-4838efb0c18e	API call failed (An error occurred (InvalidClusterParameterGroupState) when calling the ModifyClusterParameterGroup operation: There is a modify-parameter-group task in progress , please try again later. ); backing off and retrying...
"
1672979238306,"[INFO]	2023-01-06T04:27:18.306Z	afebb0f3-e3e5-47f0-b633-4838efb0c18e	Parameter group: redshift-custom-test-e2e-cloudformation-1
"
1672979238450,"[INFO]	2023-01-06T04:27:18.450Z	afebb0f3-e3e5-47f0-b633-4838efb0c18e	Parameter group updated to set parameter: enable_user_activity_logging
"
1672979238574,"[INFO]	2023-01-06T04:27:18.573Z	afebb0f3-e3e5-47f0-b633-4838efb0c18e	Ensured a user activity enabled
"
1672979238722,"[INFO]	2023-01-06T04:27:18.722Z	afebb0f3-e3e5-47f0-b633-4838efb0c18e	Cluster requires reboot.
"
1672979238859,"[INFO]	2023-01-06T04:27:18.859Z	afebb0f3-e3e5-47f0-b633-4838efb0c18e	Cluster rebooted. Waiting to start.
"
1672979299242,"[INFO]	2023-01-06T04:28:19.242Z	afebb0f3-e3e5-47f0-b633-4838efb0c18e	Cluster started after reboot.
"
1672979299243,"[INFO]	2023-01-06T04:28:19.243Z	afebb0f3-e3e5-47f0-b633-4838efb0c18e	User audit logging configured successfully
"
1672979301559,"[INFO]	2023-01-06T04:28:21.559Z	afebb0f3-e3e5-47f0-b633-4838efb0c18e	Finished: create user selectstar with password disable syslog access unrestricted;
"
1672979303799,"[INFO]	2023-01-06T04:28:23.798Z	afebb0f3-e3e5-47f0-b633-4838efb0c18e	Finished: grant select on SVV_TABLE_INFO to selectstar;
"
1672979306022,"[INFO]	2023-01-06T04:28:26.022Z	afebb0f3-e3e5-47f0-b633-4838efb0c18e	Finished: grant select on SVV_TABLES to selectstar;
"
1672979308255,"[INFO]	2023-01-06T04:28:28.255Z	afebb0f3-e3e5-47f0-b633-4838efb0c18e	Finished: grant select on SVV_COLUMNS to selectstar;
"
1672979310466,"[INFO]	2023-01-06T04:28:30.466Z	afebb0f3-e3e5-47f0-b633-4838efb0c18e	Finished: grant select on STL_QUERYTEXT to selectstar;
"
1672979312668,"[INFO]	2023-01-06T04:28:32.668Z	afebb0f3-e3e5-47f0-b633-4838efb0c18e	Finished: grant select on STL_DDLTEXT to selectstar;
"
1672979314879,"[INFO]	2023-01-06T04:28:34.879Z	afebb0f3-e3e5-47f0-b633-4838efb0c18e	Finished: grant select on STL_QUERY to selectstar;
"
1672979317102,"[INFO]	2023-01-06T04:28:37.102Z	afebb0f3-e3e5-47f0-b633-4838efb0c18e	Finished: grant select on SVV_TABLE_INFO to selectstar;
"
1672979319321,"[INFO]	2023-01-06T04:28:39.321Z	afebb0f3-e3e5-47f0-b633-4838efb0c18e	Finished: grant select on SVV_TABLES to selectstar;
"
1672979321518,"[INFO]	2023-01-06T04:28:41.517Z	afebb0f3-e3e5-47f0-b633-4838efb0c18e	Finished: grant select on SVV_COLUMNS to selectstar;
"
1672979323718,"[INFO]	2023-01-06T04:28:43.718Z	afebb0f3-e3e5-47f0-b633-4838efb0c18e	Finished: grant select on STL_QUERYTEXT to selectstar;
"
1672979325927,"[INFO]	2023-01-06T04:28:45.927Z	afebb0f3-e3e5-47f0-b633-4838efb0c18e	Finished: grant select on STL_DDLTEXT to selectstar;
"
1672979328141,"[INFO]	2023-01-06T04:28:48.141Z	afebb0f3-e3e5-47f0-b633-4838efb0c18e	Finished: grant select on STL_QUERY to selectstar;
"
1672979328142,"https://cloudformation-custom-resource-response-eucentral1.s3.eu-central-1.amazonaws.com/arn%3Aaws%3Acloudformation%3Aeu-central-1%3A792169733636%3Astack/stack-41ba30e45d28c5c3-test-e2e-cloudformation/fcea82e0-8d79-11ed-84de-061989515ff8%7CLambdaProvision%7C91c7e133-b38b-4240-9e9e-f4d6693a076a?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20230106T042541Z&X-Amz-SignedHeaders=host&X-Amz-Expires=7200&X-Amz-Credential=AKIAYYGVRKE7HVD63OFC%2F20230106%2Feu-central-1%2Fs3%2Faws4_request&X-Amz-Signature=da235534a54b9647ce730f73c5be7145c4ca982a8eabaf611726069f6796cf95
"
1672979328142,"Response body:
"
1672979328142,"{""Status"": ""SUCCESS"", ""Reason"": ""Create complete"", ""PhysicalResourceId"": ""2023/01/06/[$LATEST]2882e6e19bb4491b8e5b5a31b70005df"", ""StackId"": ""arn:aws:cloudformation:eu-central-1:792169733636:stack/stack-41ba30e45d28c5c3-test-e2e-cloudformation/fcea82e0-8d79-11ed-84de-061989515ff8"", ""RequestId"": ""91c7e133-b38b-4240-9e9e-f4d6693a076a"", ""LogicalResourceId"": ""LambdaProvision"", ""NoEcho"": false, ""Data"": {""LoggingBucket"": ""stack-41ba30e45d28c5c3-test-e2e-clo-loggingbucket-ycs3o5tves5j"", ""EndpointPort"": 5439, ""SecurityGroupId"": ""sg-0adee57443af17522""}}
"
1672979328434,"Status code: 200
"
1672979328436,"END RequestId: afebb0f3-e3e5-47f0-b633-4838efb0c18e
"
1672979328436,"REPORT RequestId: afebb0f3-e3e5-47f0-b633-4838efb0c18e	Duration: 185541.43 ms	Billed Duration: 185542 ms	Memory Size: 128 MB	Max Memory Used: 78 MB	Init Duration: 767.73 ms	
XRAY TraceId: 1-63b7a2c5-6fd2374813602c6429dcb9ca	SegmentId: 78cacdce6a3c35b0	Sampled: true	
"
```

## How to reproduce/test?

<!-- Please please provide links or steps which help to check your submission. You can also put any evidence "works for me" here. --> 

## Type of change

-   [ ] Refactor (non-breaking change that improves codebase).
-   [ ] Bug fix (non-breaking change that fixes an issue).
-   [ ] New feature (non-breaking change that adds functionality).
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
-   [ ] Chore (none of the above, but still important)

## Related tickets

-   Story sc-38653

## Checklists

-   [ ] No backend changes needed.
-   [ ] All related backend changes are ready.
    -   [links to related PRs]
