### PR TITLE
Add Terraform module for provisioning Redshfit [sc-47175]

### DIFF
--- a/redshift/terraform/README.md
+++ b/redshift/terraform/README.md
@@ -1,0 +1,77 @@
+# Terraform module for Redshift integration
+
+## Usage
+
+For basic Terraform module usage, refer to Terraform tutorial "[Reuse Configuration with Modules](https://developer.hashicorp.com/terraform/tutorials/modules)".
+
+Please use [Select Star Panel](https://app.selectstar.com/) to get the correct values of authorization parameters `iam_principal` and `external_id`.
+
+Example snippet usage:
+
+```terraform
+module "stack" {
+  source = "github.com/selectstar/cloudformation-templates//redshift/terraform"
+
+  cluster_identifier    = "X" # set to your Redshift cluster identifier, eg. aws_redshift_cluster.primary.cluster_identifier
+  provisioning_user     = "awsuser" # set to provisioning user, master user preferred, eg. aws_redshift_cluster.primary.master_username
+  provisioning_database = "dev" # set to database to connect to Redshift, eg. aws_redshift_cluster.primary.database_name
+  external_id           = "X" # available in add new data source form
+  iam_principal         = "X" # available in add new data source form
+}
+```
+
+Once the module is provisioned, you need to share output `role_arn` (eg. use `module.stack.role_arn`) with Select Star.
+
+## Update docs
+
+To update Terraform documentation use [terraform-docs](https://terraform-docs.io/) with the command:
+
+```
+terraform-docs markdown . --output-file README.md
+```
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| <a name="provider_random"></a> [random](#provider\_random) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_cloudformation_stack.stack-master](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudformation_stack) | resource |
+| [random_id.master-identifier](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
+| [aws_redshift_cluster.redshift](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/redshift_cluster) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_cluster_identifier"></a> [cluster\_identifier](#input\_cluster\_identifier) | AWS Redshift cluster identifier | `string` | n/a | yes |
+| <a name="input_configure_s3_logging"></a> [configure\_s3\_logging](#input\_configure\_s3\_logging) | If true and S3 logging disabled then the Redshift cluster configuration can be changed to enable S3 logging. It is recommended to set the value "true". | `bool` | `true` | no |
+| <a name="input_configure_s3_logging_restart"></a> [configure\_s3\_logging\_restart](#input\_configure\_s3\_logging\_restart) | If true and logging changes made then the Redshift cluster can be restarted to apply changes. It is recommended to set the value "true". | `bool` | `true` | no |
+| <a name="input_database_grant"></a> [database\_grant](#input\_database\_grant) | A comma-separated list of databases to which Select Star will be granted access. We recommend granting access to "*" (all existing databases) and selecting ingested database on the application side. | `string` | `"*"` | no |
+| <a name="input_external_id"></a> [external\_id](#input\_external\_id) | The Select Star external ID to authenticate your AWS account. It is unique for each data source and it is available in adding new data source form. | `string` | n/a | yes |
+| <a name="input_iam_principal"></a> [iam\_principal](#input\_iam\_principal) | The Select Star IAM principal which will have granted permission to your AWS account. This may be specific to a given data source and it is available in adding new data source form. | `string` | n/a | yes |
+| <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | AWS CloudFormation stack prefix name | `string` | `"selectstar-redshift"` | no |
+| <a name="input_provisioning_database"></a> [provisioning\_database](#input\_provisioning\_database) | The Redshift database used for connect to Redshift. This user is only used for provisioning new user. It can be any existing database. | `string` | n/a | yes |
+| <a name="input_provisioning_user"></a> [provisioning\_user](#input\_provisioning\_user) | The Redshift username used for provisioning our Redshift user. This user is only used for provisioning new user. It is recommended to use Redshift master user. | `string` | n/a | yes |
+| <a name="input_template_url"></a> [template\_url](#input\_template\_url) | The URL of CloudFormation Template used to provisioning integration. Don't change it unless you really know what you are doing. | `string` | `"https://select-star-production-cloudformation.s3.us-east-2.amazonaws.com/redshift/SelectStarRedshift.json"` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_role_arn"></a> [role\_arn](#output\_role\_arn) | Identifier of AWS IAM Role intended for use by Select Star to access the Redshift cluster and logs. Needs to be shared with Select Star in adding new data source form. |
+<!-- END_TF_DOCS -->

--- a/redshift/terraform/main.tf
+++ b/redshift/terraform/main.tf
@@ -1,0 +1,34 @@
+resource "random_id" "master-identifier" {
+  keepers = {
+    prefix = var.name_prefix
+    identifier = var.cluster_identifier
+  }
+  byte_length = 8
+}
+
+data "aws_redshift_cluster" "redshift" {
+  cluster_identifier = var.cluster_identifier
+}
+
+resource "aws_cloudformation_stack" "stack-master" {
+  name = "${var.name_prefix}-${random_id.master-identifier.hex}"
+
+  disable_rollback = true
+
+  parameters = {
+    Cluster                   = data.aws_redshift_cluster.redshift.cluster_identifier
+    Grant                     = var.database_grant
+    Db                        = var.provisioning_database
+    ExternalId                = var.external_id
+    DbUser                    = var.provisioning_user
+    IamPrincipal              = var.iam_principal
+    CidrIpPrimary             = "3.23.108.85/32"
+    CidrIpSecondary           = "3.20.56.105/32"
+    ConfigureS3Logging        = var.configure_s3_logging
+    ConfigureS3LoggingRestart = var.configure_s3_logging_restart
+    SentryDsn                 = "https://14d65555628a4b6f84fcb83ef1511778@o407979.ingest.sentry.io/6639248"
+  }
+
+  capabilities = ["CAPABILITY_IAM"]
+  template_url = var.template_url
+}

--- a/redshift/terraform/outputs.tf
+++ b/redshift/terraform/outputs.tf
@@ -1,0 +1,4 @@
+output "role_arn" {
+  value       = aws_cloudformation_stack.stack-master.outputs.RoleArn
+  description = "Identifier of AWS IAM Role intended for use by Select Star to access the Redshift cluster and logs. Needs to be shared with Select Star in adding new data source form."
+}

--- a/redshift/terraform/variables.tf
+++ b/redshift/terraform/variables.tf
@@ -1,0 +1,63 @@
+variable "name_prefix" {
+  type        = string
+  default     = "selectstar-redshift"
+  description = "AWS CloudFormation stack prefix name"
+}
+
+variable "cluster_identifier" {
+  type        = string
+  description = "AWS Redshift cluster identifier"
+}
+
+variable "database_grant" {
+  type        = string
+  default     = "*"
+  description = "A comma-separated list of databases to which Select Star will be granted access. We recommend granting access to \"*\" (all existing databases) and selecting ingested database on the application side."
+}
+
+variable "provisioning_user" {
+  type        = string
+  nullable    = false
+  description = "The Redshift username used for provisioning our Redshift user. This user is only used for provisioning new user. It is recommended to use Redshift master user."
+}
+
+variable "provisioning_database" {
+  type        = string
+  nullable    = false
+  description = "The Redshift database used for connect to Redshift. This user is only used for provisioning new user. It can be any existing database."
+}
+
+variable "external_id" {
+  type        = string
+  nullable    = false
+  description = "The Select Star external ID to authenticate your AWS account. It is unique for each data source and it is available in adding new data source form."
+}
+
+variable "iam_principal" {
+  type        = string
+  nullable    = false
+  description = "The Select Star IAM principal which will have granted permission to your AWS account. This may be specific to a given data source and it is available in adding new data source form."
+
+  validation {
+    condition     = can(regex("^arn:aws:iam::", var.iam_principal))
+    error_message = "Invalid IAM principal ARN."
+  }
+}
+
+variable "configure_s3_logging" {
+  type        = bool
+  default     = true
+  description = "If true and S3 logging disabled then the Redshift cluster configuration can be changed to enable S3 logging. It is recommended to set the value \"true\"."
+}
+
+variable "configure_s3_logging_restart" {
+  type        = bool
+  default     = true
+  description = "If true and logging changes made then the Redshift cluster can be restarted to apply changes. It is recommended to set the value \"true\"."
+}
+
+variable "template_url" {
+  type        = string
+  default     = "https://select-star-production-cloudformation.s3.us-east-2.amazonaws.com/redshift/SelectStarRedshift.json"
+  description = "The URL of CloudFormation Template used to provisioning integration. Don't change it unless you really know what you are doing."
+}


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change. -->

Introduces Terraform module for provisioning Redshift on request on request from one of the prospects.

To provide minimal product it uses AWS CloudFormation to provision all components.

Incorporated in E2E tests.

## How to reproduce/test?

<!-- Please please provide links or steps which help to check your submission. You can also put any evidence "works for me" here. --> 

Follow the README of Terraform module or use E2E tests

## Type of change

-   [ ] Refactor (non-breaking change that improves codebase).
-   [ ] Bug fix (non-breaking change that fixes an issue).
-   [ ] New feature (non-breaking change that adds functionality).
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
-   [ ] Chore (none of the above, but still important)

## Related tickets

-   Story sc-47175

## Checklists

-   [ ] No backend changes needed.
-   [ ] All related backend changes are ready.
    -   [links to related PRs]
