### PR TITLE
Reduce permission of 'PassRole' [sc-47467]

### DIFF
--- a/redshift/SelectStarRedshift.json
+++ b/redshift/SelectStarRedshift.json
@@ -344,7 +344,7 @@
                         }
                     ]
                 },
-                "PolicyName": "EnableSelectStar",
+                "PolicyName": "EnableSelectStarAccess",
                 "Roles": [
                     {
                         "Ref": "CrossAccountRole"
@@ -396,124 +396,138 @@
                         }
                     ]
                 },
-                "Policies": [
-                    {
-                        "PolicyName": "RedshiftAccess",
-                        "PolicyDocument": {
-                            "Version": "2012-10-17",
-                            "Statement": [
-                                {
-                                    "Effect": "Allow",
-                                    "Action": [
-                                        "redshift:*",
-                                        "redshift-data:*"
-                                    ],
-                                    "Resource": [
-                                        {
-                                            "Fn::Sub": "arn:aws:redshift:${AWS::Region}:${AWS::AccountId}:dbuser:${Cluster}/${DbUser}"
-                                        },
-                                        {
-                                            "Fn::Sub": "arn:aws:redshift:${AWS::Region}:${AWS::AccountId}:dbname:${Cluster}/*"
-                                        },
-                                        {
-                                            "Fn::Sub": "arn:aws:redshift:${AWS::Region}:${AWS::AccountId}:cluster:${Cluster}"
-                                        },
-                                        {
-                                            "Fn::Sub": "arn:aws:redshift:${AWS::Region}:${AWS::AccountId}:parametergroup:*"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "Effect": "Allow",
-                                    "Action": [
-                                        "redshift-data:DescribeStatement",
-                                        "redshift:DescribeClusterParameterGroups"
-                                    ],
-                                    "Resource": "*"
-                                },
-                                {
-                                    "Effect": "Allow",
-                                    "Action": [
-                                        "iam:PassRole"
-                                    ],
-                                    "Resource": "*"
-                                },
-                                {
-                                    "Effect": "Allow",
-                                    "Action": [
-                                        "s3:*"
-                                    ],
-                                    "Resource": [
-                                        {
-                                            "Fn::Sub": [
-                                                "arn:aws:s3:::${BucketName}",
-                                                {
-                                                    "BucketName": {
-                                                        "Ref": "LambdaBucket"
-                                                    }
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "Fn::Sub": [
-                                                "arn:aws:s3:::${BucketName}/*",
-                                                {
-                                                    "BucketName": {
-                                                        "Ref": "LambdaBucket"
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                },
-                                {
-                                    "Effect": "Allow",
-                                    "Action": [
-                                        "s3:GetObject"
-                                    ],
-                                    "Resource": "*"
-                                },
-                                {
-                                    "Effect": "Allow",
-                                    "Resource": [
-                                        {
-                                            "Fn::Join": [
-                                                "",
-                                                [
-                                                    "arn:aws:s3:::",
-                                                    {
-                                                        "Ref": "LoggingBucket"
-                                                    }
-                                                ]
-                                            ]
-                                        },
-                                        {
-                                            "Fn::Join": [
-                                                "",
-                                                [
-                                                    "arn:aws:s3:::",
-                                                    {
-                                                        "Ref": "LoggingBucket"
-                                                    },
-                                                    "/*"
-                                                ]
-                                            ]
-                                        }
-                                    ],
-                                    "Action": "*"
-                                }
-                            ]
-                        }
-                    }
-                ],
                 "ManagedPolicyArns": [
                     "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
                     "arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess"
                 ]
             }
         },
+        "LambdaRolePolicy": {
+            "Type": "AWS::IAM::Policy",
+            "Properties": {
+                "PolicyDocument": {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Action": [
+                                "redshift:*",
+                                "redshift-data:*"
+                            ],
+                            "Resource": [
+                                {
+                                    "Fn::Sub": "arn:aws:redshift:${AWS::Region}:${AWS::AccountId}:dbuser:${Cluster}/${DbUser}"
+                                },
+                                {
+                                    "Fn::Sub": "arn:aws:redshift:${AWS::Region}:${AWS::AccountId}:dbname:${Cluster}/*"
+                                },
+                                {
+                                    "Fn::Sub": "arn:aws:redshift:${AWS::Region}:${AWS::AccountId}:cluster:${Cluster}"
+                                },
+                                {
+                                    "Fn::Sub": "arn:aws:redshift:${AWS::Region}:${AWS::AccountId}:parametergroup:*"
+                                }
+                            ]
+                        },
+                        {
+                            "Effect": "Allow",
+                            "Action": [
+                                "redshift-data:DescribeStatement",
+                                "redshift:DescribeClusterParameterGroups"
+                            ],
+                            "Resource": "*"
+                        },
+                        {
+                            "Effect": "Allow",
+                            "Action": [
+                                "iam:PassRole"
+                            ],
+                            "Resource": {
+                                "Fn::GetAtt": [
+                                    "CrossAccountRole",
+                                    "Arn"
+                                ]
+                            }
+                        },
+                        {
+                            "Effect": "Allow",
+                            "Action": [
+                                "s3:*"
+                            ],
+                            "Resource": [
+                                {
+                                    "Fn::Sub": [
+                                        "arn:aws:s3:::${BucketName}",
+                                        {
+                                            "BucketName": {
+                                                "Ref": "LambdaBucket"
+                                            }
+                                        }
+                                    ]
+                                },
+                                {
+                                    "Fn::Sub": [
+                                        "arn:aws:s3:::${BucketName}/*",
+                                        {
+                                            "BucketName": {
+                                                "Ref": "LambdaBucket"
+                                            }
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "Effect": "Allow",
+                            "Action": [
+                                "s3:GetObject"
+                            ],
+                            "Resource": "*"
+                        },
+                        {
+                            "Effect": "Allow",
+                            "Resource": [
+                                {
+                                    "Fn::Join": [
+                                        "",
+                                        [
+                                            "arn:aws:s3:::",
+                                            {
+                                                "Ref": "LoggingBucket"
+                                            }
+                                        ]
+                                    ]
+                                },
+                                {
+                                    "Fn::Join": [
+                                        "",
+                                        [
+                                            "arn:aws:s3:::",
+                                            {
+                                                "Ref": "LoggingBucket"
+                                            },
+                                            "/*"
+                                        ]
+                                    ]
+                                }
+                            ],
+                            "Action": "*"
+                        }
+                    ]
+                },
+                "PolicyName": "EnableSelectStarProvisioning",
+                "Roles": [
+                    {
+                        "Ref": "LambdaRole"
+                    }
+                ]
+            }
+        },
         "LambdaProvisionFunction": {
             "Type": "AWS::Lambda::Function",
+            "DependsOn": [
+                "LambdaRolePolicy"
+            ],
             "Properties": {
                 "Timeout": 300,
                 "Code": {

--- a/redshift/e2e/main.tf
+++ b/redshift/e2e/main.tf
@@ -106,7 +106,7 @@ module "stack-master" {
   provisioning_user     = aws_redshift_cluster.e2e.master_username
   provisioning_database = aws_redshift_cluster.e2e.database_name
   external_id           = "X"
-  iam_principal         = data.aws_caller_identity.current.account_id
+  iam_principal         = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
 
   template_url = local.template_url
 

--- a/redshift/terraform/variables.tf
+++ b/redshift/terraform/variables.tf
@@ -40,7 +40,7 @@ variable "iam_principal" {
 
   validation {
     condition     = can(regex("^arn:aws:iam::", var.iam_principal))
-    error_message = "Invalid IAM principal ARN."
+    error_message = "Invalid IAM principal. You must enter a valid ARN."
   }
 }
 


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change. -->

We initially granted permission `iam:PassRole` to all resources for the IAM role used for the provisioning of Redshift. 

We assumed that this does not cause a problem, because Lambda can only perform a small number of operations provided for in the code, so we wanted to simplify our implementation. However, the consumer has had a compatibility issue in this area, so we are restricting permissions.

This does not affect the permissions of the final integration. 
## How to reproduce/test?

<!-- Please please provide links or steps which help to check your submission. You can also put any evidence "works for me" here. --> 

Execute e2e test.

## Type of change

-   [ ] Refactor (non-breaking change that improves codebase).
-   [ ] Bug fix (non-breaking change that fixes an issue).
-   [ ] New feature (non-breaking change that adds functionality).
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
-   [ ] Chore (none of the above, but still important)

## Related tickets

-   Story sc-47467

## Checklists

-   [ ] No backend changes needed.
-   [ ] All related backend changes are ready.
    -   [links to related PRs]
