### PR TITLE
grant write permission to pull-requests when running the pr-assign GH workflow action [sc-46139]

### DIFF
--- a/.github/workflows/pr-assign.yml
+++ b/.github/workflows/pr-assign.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, reopened]
 
+permissions:
+  pull-requests: write
+
 jobs:
   assign:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

By default, the GITHUB_TOKEN does not have sufficient permissions to modify the PR, but these can be modified per-workflow, or even per-job. Adding the write permission fixes the workflow.

## How to reproduce/test?

The pr-assign workflow should start succeeding after this change.

## Type of change

-   [ ] Refactor (non-breaking change that improves codebase).
-   [ ] Bug fix (non-breaking change that fixes an issue).
-   [ ] New feature (non-breaking change that adds functionality).
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
-   [x] Chore (none of the above, but still important)

## Related tickets

-   Story sc-46139

## Checklists

-   [x] No backend changes needed.
-   [ ] All related backend changes are ready.
    -   [links to related PRs]
