### PR TITLE
grant write permissions for PRs to the pr-lint workflow job [sc-46139]

### DIFF
--- a/.github/workflows/pr-lint.yaml
+++ b/.github/workflows/pr-lint.yaml
@@ -11,6 +11,9 @@ on:
 jobs:
   check:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: wrire
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v2

--- a/.github/workflows/pr-lint.yaml
+++ b/.github/workflows/pr-lint.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: wrire
+      pull-requests: write
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v2


### PR DESCRIPTION
## Description

By default, the `GITHUB_TOKEN` does not have sufficient permissions to modify the PR, but these can be modified per-workflow or per-job. Adding the write permissions (and also including the content read permission which is present by default, but is removed when we set any permissions explicitly) fixes the "PR Lint / check" workflow.

## How to reproduce/test?

The "PR Lint / check" workflow should start passing and syncing labels from Shortcut after this change.

## Type of change

-   [ ] Refactor (non-breaking change that improves codebase).
-   [ ] Bug fix (non-breaking change that fixes an issue).
-   [ ] New feature (non-breaking change that adds functionality).
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
-   [x] Chore (none of the above, but still important)

## Related tickets

-   Story sc-46139

## Checklists

-   [x] No backend changes needed.
-   [ ] All related backend changes are ready.
    -   [links to related PRs]
