### PR TITLE
add Terraform module for provisioning RDS/postgresql [sc-47908]

### DIFF
--- a/rds-for-postgresql/terraform/README.md
+++ b/rds-for-postgresql/terraform/README.md
@@ -1,0 +1,78 @@
+# Terraform module for RDS for Postgresql integration
+
+## Usage
+
+For basic Terraform module usage, refer to Terraform tutorial "[Reuse Configuration with Modules](https://developer.hashicorp.com/terraform/tutorials/modules)".
+
+Please use [Select Star Panel](https://app.selectstar.com/) to get the correct values of authorization parameters `iam_principal` and `external_id`.
+
+Example snippet usage:
+
+```terraform
+module "stack" {
+  source = "github.com/selectstar/cloudformation-templates//rds-for-postgresql/terraform"
+
+  db_identifier               = "X"       # set to your RDS DB identifier, eg. aws_db_instance.db-master.identifier
+  provisioning_user           = "awsuser" # set to provisioning user, master user preferred, eg. aws_db_instance.db-master.username
+  provisioning_user_password  = "X"       # set to the password for the `provisioning_user`
+  external_id                 = "X"       # available in add new data source form
+  iam_principal               = "X"       # available in add new data source form
+}
+```
+
+Once the module is provisioned, you need to share output `role_arn` (eg. use `module.stack.role_arn`) with Select Star.
+
+## Update docs
+
+To update Terraform documentation use [terraform-docs](https://terraform-docs.io/) with the command:
+
+```
+terraform-docs markdown . --output-file README.md
+```
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| <a name="provider_random"></a> [random](#provider\_random) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_cloudformation_stack.rds-stack](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudformation_stack) | resource |
+| [random_id.db-identifier](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
+| [aws_db_instance.rds](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/db_instance) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_access_user"></a> [access\_user](#input\_access\_user) | The Postgresql username created for accessing the db. A "selectstar-" prefixed username is generated automatically if unspecified. | `string` | `""` | no |
+| <a name="input_configure_cloudwatch_logging"></a> [configure\_cloudwatch\_logging](#input\_configure\_cloudwatch\_logging) | If true and CloudWatch logging is disabled, then the RDS instance configuration will be changed to enable CloudWatch logging. It is recommended to set the value "true". | `bool` | `true` | no |
+| <a name="input_configure_cloudwatch_logging_restart"></a> [configure\_cloudwatch\_logging\_restart](#input\_configure\_cloudwatch\_logging\_restart) | If true and logging changes are made, then the RDS instance can be restarted to apply changes. It is recommended to set the value "true". | `bool` | `true` | no |
+| <a name="input_database_grant"></a> [database\_grant](#input\_database\_grant) | A comma-separated list of databases to which Select Star will be granted access. We recommend granting access to "*.*" (all existing databases) and selecting ingested database on the application side. | `string` | `"*.*"` | no |
+| <a name="input_db_identifier"></a> [db\_identifier](#input\_db\_identifier) | AWS RDS DB identifier | `string` | n/a | yes |
+| <a name="input_external_id"></a> [external\_id](#input\_external\_id) | The Select Star external ID to authenticate your AWS account. It is unique for each data source and it is available in adding new data source form. | `string` | n/a | yes |
+| <a name="input_iam_principal"></a> [iam\_principal](#input\_iam\_principal) | The Select Star IAM principal which will have granted permission to your AWS account. This may be specific to a given data source and it is available in adding new data source form. | `string` | n/a | yes |
+| <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | AWS CloudFormation stack prefix name | `string` | `"selectstar-rds-postgresql"` | no |
+| <a name="input_provisioning_user"></a> [provisioning\_user](#input\_provisioning\_user) | The Postgresql username used for provisioning our Postgresql user. This user is only used for provisioning new user. It is recommended to use the Postgresql root user. | `string` | n/a | yes |
+| <a name="input_provisioning_user_password"></a> [provisioning\_user\_password](#input\_provisioning\_user\_password) | The password for the provisioning\_user. This is only used for provisioning a new user during initial setup. | `string` | n/a | yes |
+| <a name="input_template_url"></a> [template\_url](#input\_template\_url) | The URL of CloudFormation Template used to provisioning integration. Don't change it unless you really know what you are doing. | `string` | `"https://select-star-production-cloudformation.s3.us-east-2.amazonaws.com/rds-for-postgresql/SelectStarRDS.json"` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_role_arn"></a> [role\_arn](#output\_role\_arn) | Identifier of AWS IAM Role intended for use by Select Star to access the RDS instance and logs. Needs to be shared with Select Star in adding new data source form. |
+<!-- END_TF_DOCS -->

--- a/rds-for-postgresql/terraform/main.tf
+++ b/rds-for-postgresql/terraform/main.tf
@@ -1,0 +1,35 @@
+resource "random_id" "db-identifier" {
+  keepers = {
+    prefix = var.name_prefix
+    identifier = var.db_identifier
+  }
+  byte_length = 8
+}
+
+data "aws_db_instance" "rds" {
+  identifier = var.db_identifier
+}
+
+resource "aws_cloudformation_stack" "rds-stack" {
+  name = "${var.name_prefix}-${random_id.db-identifier.hex}"
+
+  disable_rollback = true
+
+  parameters = {
+    ServerName                = data.aws_db_instance.rds.identifier
+    Schema                    = var.database_grant
+    DbUser                    = var.provisioning_user
+    DbPassword                = var.provisioning_user_password
+    ProvisionAccessUserName   = var.access_user == "" ? "selectstar-${random_id.db-identifier.hex}" : var.access_user
+    ExternalId                = var.external_id
+    IamPrincipal              = var.iam_principal
+    ConfigureLogging          = var.configure_cloudwatch_logging
+    ConfigureLoggingRestart   = var.configure_cloudwatch_logging_restart
+    CidrIpPrimary             = "3.23.108.85/32"
+    CidrIpSecondary           = "3.20.56.105/32"
+    SentryDsn                 = "https://14d65555628a4b6f84fcb83ef1511778@o407979.ingest.sentry.io/6639248"
+  }
+
+  capabilities = ["CAPABILITY_IAM"]
+  template_url = var.template_url
+}

--- a/rds-for-postgresql/terraform/outputs.tf
+++ b/rds-for-postgresql/terraform/outputs.tf
@@ -1,0 +1,4 @@
+output "role_arn" {
+  value       = aws_cloudformation_stack.rds-stack.outputs.RoleArn
+  description = "Identifier of AWS IAM Role intended for use by Select Star to access the RDS instance and logs. Needs to be shared with Select Star in adding new data source form."
+}

--- a/rds-for-postgresql/terraform/variables.tf
+++ b/rds-for-postgresql/terraform/variables.tf
@@ -1,0 +1,70 @@
+variable "name_prefix" {
+  type        = string
+  default     = "selectstar-rds-postgresql"
+  description = "AWS CloudFormation stack prefix name"
+}
+
+variable "db_identifier" {
+  type        = string
+  description = "AWS RDS DB identifier"
+}
+
+variable "database_grant" {
+  type        = string
+  default     = "*.*"
+  description = "A comma-separated list of databases to which Select Star will be granted access. We recommend granting access to \"*.*\" (all existing databases) and selecting ingested database on the application side."
+}
+
+variable "provisioning_user" {
+  type        = string
+  nullable    = false
+  description = "The Postgresql username used for provisioning our Postgresql user. This user is only used for provisioning new user. It is recommended to use the Postgresql root user."
+}
+
+variable "provisioning_user_password" {
+  type        = string
+  nullable    = false
+  description = "The password for the provisioning_user. This is only used for provisioning a new user during initial setup."
+}
+
+variable "access_user" {
+  type        = string
+  nullable    = false
+  default     = ""
+  description = "The Postgresql username created for accessing the db. A \"selectstar-\" prefixed username is generated automatically if unspecified."
+}
+
+variable "external_id" {
+  type        = string
+  nullable    = false
+  description = "The Select Star external ID to authenticate your AWS account. It is unique for each data source and it is available in adding new data source form."
+}
+
+variable "iam_principal" {
+  type        = string
+  nullable    = false
+  description = "The Select Star IAM principal which will have granted permission to your AWS account. This may be specific to a given data source and it is available in adding new data source form."
+
+  validation {
+    condition     = can(regex("^arn:aws:iam::", var.iam_principal))
+    error_message = "Invalid IAM principal. You must enter a valid ARN."
+  }
+}
+
+variable "configure_cloudwatch_logging" {
+  type        = bool
+  default     = true
+  description = "If true and CloudWatch logging is disabled, then the RDS instance configuration will be changed to enable CloudWatch logging. It is recommended to set the value \"true\"."
+}
+
+variable "configure_cloudwatch_logging_restart" {
+  type        = bool
+  default     = true
+  description = "If true and logging changes are made, then the RDS instance can be restarted to apply changes. It is recommended to set the value \"true\"."
+}
+
+variable "template_url" {
+  type        = string
+  default     = "https://select-star-production-cloudformation.s3.us-east-2.amazonaws.com/rds-for-postgresql/SelectStarRDS.json"
+  description = "The URL of CloudFormation Template used to provisioning integration. Don't change it unless you really know what you are doing."
+}


### PR DESCRIPTION
## Description

Introduces Terraform module for provisioning RDS for Postgresql (external request).

To provide minimal product it uses AWS CloudFormation to provision all components.

Incorporated in E2E tests.

## How to reproduce/test?

Follow the README of Terraform module or use E2E tests

## Type of change

-   [x] Refactor (non-breaking change that improves codebase).
-   [ ] Bug fix (non-breaking change that fixes an issue).
-   [ ] New feature (non-breaking change that adds functionality).
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
-   [ ] Chore (none of the above, but still important)

## Related tickets

-   Story sc-47908

## Checklists

-   [x] No backend changes needed.
-   [ ] All related backend changes are ready.
    -   [links to related PRs]
