### PR TITLE
redshift, rds: Fix race in provisioning CopyFunction [sc-47175]

### DIFF
--- a/rds-for-postgresql/SelectStarRDS.json
+++ b/rds-for-postgresql/SelectStarRDS.json
@@ -374,9 +374,6 @@
         },
         "LambdaCopy": {
             "Type": "Custom::LambdaCopy",
-            "DependsOn": [
-                "LambdaRolePolicy"
-            ],
             "Version": "1.0",
             "Properties": {
                 "ServiceToken": {

--- a/rds-for-postgresql/SelectStarRDS.json
+++ b/rds-for-postgresql/SelectStarRDS.json
@@ -374,6 +374,9 @@
         },
         "LambdaCopy": {
             "Type": "Custom::LambdaCopy",
+            "DependsOn": [
+                "LambdaRolePolicy"
+            ],
             "Version": "1.0",
             "Properties": {
                 "ServiceToken": {

--- a/redshift/SelectStarRedshift.json
+++ b/redshift/SelectStarRedshift.json
@@ -670,6 +670,9 @@
         },
         "LambdaCopy": {
             "Type": "Custom::LambdaCopy",
+            "DependsOn": [
+                "LambdaRolePolicy"
+            ],
             "Version": "1.0",
             "Properties": {
                 "ServiceToken": {


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change. -->

When deploying AWS CloudFormation template we provision a few resources, among others:

* `LambdaRole` (AWS IAM Role) 
* `LambdaCopyFunction` (AWS Lambda Function with code) - references `LambdaRole`
* `LambdaRolePolicy` (grant permission to AWS IAM Role)– references `LambdaRole`
* `LambdaCopy` (executes `LambdaCopyFunction`) – references `LambdaCopyFunction`

For a successful execution of `LambdaCopy` there is a need to grant permission to `LambdaRole` by `LambdaRolePolicy`, but there are no references like that, so we need to add dependencies explicitly. However, due to no dependency and no references, there is a risk of executing the Lambda function before granting permission. It results in transient errors like:

<img width="1685" alt="image" src="https://user-images.githubusercontent.com/99484706/235010369-55434b3a-c402-41df-8e64-147225591821.png">

`LambdaProvision` have already the right dependencies.

## How to reproduce/test?

<!-- Please please provide links or steps which help to check your submission. You can also put any evidence "works for me" here. --> 

## Type of change

-   [ ] Refactor (non-breaking change that improves codebase).
-   [ ] Bug fix (non-breaking change that fixes an issue).
-   [ ] New feature (non-breaking change that adds functionality).
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
-   [ ] Chore (none of the above, but still important)

## Related tickets

-   Story sc-47175

## Checklists

-   [ ] No backend changes needed.
-   [ ] All related backend changes are ready.
    -   [links to related PRs]
