### PR TITLE
glue: Fix breaking changes about bucket permission [sc-52284]

### DIFF
--- a/glue/e2e/main.tf
+++ b/glue/e2e/main.tf
@@ -22,9 +22,11 @@ resource "aws_s3_bucket" "cloudformation-bucket" {
   bucket_prefix = "e2e-test"
 }
 
-resource "aws_s3_bucket_acl" "cloudformation-bucket" {
+resource "aws_s3_bucket_ownership_controls" "cloudformation-bucket" {
   bucket = aws_s3_bucket.cloudformation-bucket.id
-  acl    = "public-read"
+  rule {
+    object_ownership = "BucketOwnerEnforced"
+  }
 }
 
 resource "aws_s3_object" "cloudformation-object" {
@@ -32,7 +34,6 @@ resource "aws_s3_object" "cloudformation-object" {
 
   key    = "SelectStarGlue.json"
   source = "${path.module}/../SelectStarGlue.json"
-  acl    = "public-read"
 
   etag = filemd5("${path.module}/../SelectStarGlue.json")
 }


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change. -->

AWS introduced breaking changes around bucket creation. We already fixed that for Redshift (#46), so we are syncing fix to AWS Glue.

## How to reproduce/test?

<!-- Please please provide links or steps which help to check your submission. You can also put any evidence "works for me" here. --> 

Successfully provisioned by e2e test:

```
❯ AWS_PROFILE=playground terraform apply
data.aws_availability_zones.available: Reading...
data.aws_caller_identity.current: Reading...
data.aws_availability_zones.available: Read complete after 0s [id=eu-central-1]
data.aws_caller_identity.current: Read complete after 0s [id=792169733636]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # aws_glue_workflow.workflow will be created
  + resource "aws_glue_workflow" "workflow" {
      + arn      = (known after apply)
      + id       = (known after apply)
      + name     = "example"
      + tags_all = {
          + "Component" = "test-e2e-glue"
          + "ManagedBy" = "Terraform"
        }
    }

  # aws_s3_bucket.cloudformation-bucket will be created
  + resource "aws_s3_bucket" "cloudformation-bucket" {
      + acceleration_status         = (known after apply)
      + acl                         = (known after apply)
      + arn                         = (known after apply)
      + bucket                      = (known after apply)
      + bucket_domain_name          = (known after apply)
      + bucket_prefix               = "e2e-test"
      + bucket_regional_domain_name = (known after apply)
      + force_destroy               = false
      + hosted_zone_id              = (known after apply)
      + id                          = (known after apply)
      + object_lock_enabled         = (known after apply)
      + policy                      = (known after apply)
      + region                      = (known after apply)
      + request_payer               = (known after apply)
      + tags_all                    = {
          + "Component" = "test-e2e-glue"
          + "ManagedBy" = "Terraform"
        }
      + website_domain              = (known after apply)
      + website_endpoint            = (known after apply)

      + cors_rule {
          + allowed_headers = (known after apply)
          + allowed_methods = (known after apply)
          + allowed_origins = (known after apply)
          + expose_headers  = (known after apply)
          + max_age_seconds = (known after apply)
        }

      + grant {
          + id          = (known after apply)
          + permissions = (known after apply)
          + type        = (known after apply)
          + uri         = (known after apply)
        }

      + lifecycle_rule {
          + abort_incomplete_multipart_upload_days = (known after apply)
          + enabled                                = (known after apply)
          + id                                     = (known after apply)
          + prefix                                 = (known after apply)
          + tags                                   = (known after apply)

          + expiration {
              + date                         = (known after apply)
              + days                         = (known after apply)
              + expired_object_delete_marker = (known after apply)
            }

          + noncurrent_version_expiration {
              + days = (known after apply)
            }

          + noncurrent_version_transition {
              + days          = (known after apply)
              + storage_class = (known after apply)
            }

          + transition {
              + date          = (known after apply)
              + days          = (known after apply)
              + storage_class = (known after apply)
            }
        }

      + logging {
          + target_bucket = (known after apply)
          + target_prefix = (known after apply)
        }

      + object_lock_configuration {
          + object_lock_enabled = (known after apply)

          + rule {
              + default_retention {
                  + days  = (known after apply)
                  + mode  = (known after apply)
                  + years = (known after apply)
                }
            }
        }

      + replication_configuration {
          + role = (known after apply)

          + rules {
              + delete_marker_replication_status = (known after apply)
              + id                               = (known after apply)
              + prefix                           = (known after apply)
              + priority                         = (known after apply)
              + status                           = (known after apply)

              + destination {
                  + account_id         = (known after apply)
                  + bucket             = (known after apply)
                  + replica_kms_key_id = (known after apply)
                  + storage_class      = (known after apply)

                  + access_control_translation {
                      + owner = (known after apply)
                    }

                  + metrics {
                      + minutes = (known after apply)
                      + status  = (known after apply)
                    }

                  + replication_time {
                      + minutes = (known after apply)
                      + status  = (known after apply)
                    }
                }

              + filter {
                  + prefix = (known after apply)
                  + tags   = (known after apply)
                }

              + source_selection_criteria {
                  + sse_kms_encrypted_objects {
                      + enabled = (known after apply)
                    }
                }
            }
        }

      + server_side_encryption_configuration {
          + rule {
              + bucket_key_enabled = (known after apply)

              + apply_server_side_encryption_by_default {
                  + kms_master_key_id = (known after apply)
                  + sse_algorithm     = (known after apply)
                }
            }
        }

      + versioning {
          + enabled    = (known after apply)
          + mfa_delete = (known after apply)
        }

      + website {
          + error_document           = (known after apply)
          + index_document           = (known after apply)
          + redirect_all_requests_to = (known after apply)
          + routing_rules            = (known after apply)
        }
    }

  # aws_s3_bucket_ownership_controls.cloudformation-bucket will be created
  + resource "aws_s3_bucket_ownership_controls" "cloudformation-bucket" {
      + bucket = (known after apply)
      + id     = (known after apply)

      + rule {
          + object_ownership = "BucketOwnerEnforced"
        }
    }

  # aws_s3_object.cloudformation-object will be created
  + resource "aws_s3_object" "cloudformation-object" {
      + acl                    = "private"
      + bucket                 = (known after apply)
      + bucket_key_enabled     = (known after apply)
      + content_type           = (known after apply)
      + etag                   = "a9603d0c62d0bbcafc161df41a67f0ef"
      + force_destroy          = false
      + id                     = (known after apply)
      + key                    = "SelectStarGlue.json"
      + kms_key_id             = (known after apply)
      + server_side_encryption = (known after apply)
      + source                 = "./../SelectStarGlue.json"
      + storage_class          = (known after apply)
      + tags_all               = {
          + "Component" = "test-e2e-glue"
          + "ManagedBy" = "Terraform"
        }
      + version_id             = (known after apply)
    }

  # null_resource.cluster will be created
  + resource "null_resource" "cluster" {
      + id       = (known after apply)
      + triggers = {
          + "external_id" = "external-id"
          + "role_arn"    = (known after apply)
        }
    }

  # random_id.master-identifier will be created
  + resource "random_id" "master-identifier" {
      + b64_std     = (known after apply)
      + b64_url     = (known after apply)
      + byte_length = 8
      + dec         = (known after apply)
      + hex         = (known after apply)
      + id          = (known after apply)
      + keepers     = {
          + "etag" = "a9603d0c62d0bbcafc161df41a67f0ef"
        }
    }

  # random_string.random will be created
  + resource "random_string" "random" {
      + id          = (known after apply)
      + length      = 32
      + lower       = true
      + min_lower   = 0
      + min_numeric = 0
      + min_special = 0
      + min_upper   = 0
      + number      = true
      + numeric     = true
      + result      = (known after apply)
      + special     = false
      + upper       = true
    }

  # module.stack-master.aws_cloudformation_stack.stack-master will be created
  + resource "aws_cloudformation_stack" "stack-master" {
      + capabilities     = [
          + "CAPABILITY_IAM",
        ]
      + disable_rollback = true
      + id               = (known after apply)
      + name             = (known after apply)
      + outputs          = (known after apply)
      + parameters       = {
          + "ExternalId"   = "external-id"
          + "IamPrincipal" = "arn:aws:iam::792169733636:root"
        }
      + policy_body      = (known after apply)
      + tags_all         = {
          + "Component" = "test-e2e-glue"
          + "ManagedBy" = "Terraform"
        }
      + template_body    = (known after apply)
      + template_url     = (known after apply)
    }

  # module.stack-master.random_id.master-identifier will be created
  + resource "random_id" "master-identifier" {
      + b64_std     = (known after apply)
      + b64_url     = (known after apply)
      + byte_length = 8
      + dec         = (known after apply)
      + hex         = (known after apply)
      + id          = (known after apply)
      + keepers     = {
          + "ExternalId"   = "external-id"
          + "IamPrincipal" = "arn:aws:iam::792169733636:root"
          + "prefix"       = "selectstar-redshift"
        }
    }

Plan: 9 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + role_arn = (known after apply)

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

random_string.random: Creating...
random_string.random: Creation complete after 0s [id=99fyshjxgjJrR5p47PRxKH8gOGXqLfF3]
module.stack-master.random_id.master-identifier: Creating...
aws_glue_workflow.workflow: Creating...
module.stack-master.random_id.master-identifier: Creation complete after 0s [id=vCxhTZnn80c]
aws_s3_bucket.cloudformation-bucket: Creating...
aws_glue_workflow.workflow: Creation complete after 1s [id=example]
aws_s3_bucket.cloudformation-bucket: Creation complete after 2s [id=e2e-test20230508111803867500000001]
aws_s3_bucket_ownership_controls.cloudformation-bucket: Creating...
aws_s3_object.cloudformation-object: Creating...
aws_s3_bucket_ownership_controls.cloudformation-bucket: Creation complete after 0s [id=e2e-test20230508111803867500000001]
aws_s3_object.cloudformation-object: Creation complete after 0s [id=SelectStarGlue.json]
random_id.master-identifier: Creating...
module.stack-master.aws_cloudformation_stack.stack-master: Creating...
random_id.master-identifier: Creation complete after 0s [id=r1OIm_fDEVg]
module.stack-master.aws_cloudformation_stack.stack-master: Still creating... [10s elapsed]
module.stack-master.aws_cloudformation_stack.stack-master: Still creating... [20s elapsed]
module.stack-master.aws_cloudformation_stack.stack-master: Still creating... [30s elapsed]
module.stack-master.aws_cloudformation_stack.stack-master: Still creating... [40s elapsed]
module.stack-master.aws_cloudformation_stack.stack-master: Creation complete after 47s [id=arn:aws:cloudformation:eu-central-1:792169733636:stack/selectstar-redshift-bc2c614d99e7f347/018fc1c0-ed92-11ed-b76b-0648d988f914]
null_resource.cluster: Creating...
null_resource.cluster: Provisioning with 'local-exec'...
null_resource.cluster (local-exec): Executing: ["/bin/sh" "-c" "aws sts assume-role --role-arn arn:aws:iam::792169733636:role/selectstar-redshift-bc2c614d99e7f-CrossAccountRole-9N0DOTGPMC6O --role-session-name test-e2e --duration-seconds 900 --external-id external-id"]
null_resource.cluster (local-exec): {
null_resource.cluster (local-exec):     "Credentials": {
null_resource.cluster (local-exec):         "AccessKeyId": "**CUT**",
null_resource.cluster (local-exec):         "SecretAccessKey": "**CUT**",
null_resource.cluster (local-exec):         "SessionToken": "**CUT**",
null_resource.cluster (local-exec):         "Expiration": "2023-05-08T11:33:54+00:00"
null_resource.cluster (local-exec):     },
null_resource.cluster (local-exec):     "AssumedRoleUser": {
null_resource.cluster (local-exec):         "AssumedRoleId": "AROA3Q4H63YCIENKAYOZ6:test-e2e",
null_resource.cluster (local-exec):         "Arn": "arn:aws:sts::792169733636:assumed-role/selectstar-redshift-bc2c614d99e7f-CrossAccountRole-9N0DOTGPMC6O/test-e2e"
null_resource.cluster (local-exec):     }
null_resource.cluster (local-exec): }
null_resource.cluster: Creation complete after 1s [id=3364580033513400717]

Apply complete! Resources: 9 added, 0 changed, 0 destroyed.

Outputs:

role_arn = "arn:aws:iam::792169733636:role/selectstar-redshift-bc2c614d99e7f-CrossAccountRole-9N0DOTGPMC6O"
```

Successfully deprovisioned:

```
❯ AWS_PROFILE=playground terraform destroy
random_string.random: Refreshing state... [id=99fyshjxgjJrR5p47PRxKH8gOGXqLfF3]
data.aws_availability_zones.available: Reading...
data.aws_caller_identity.current: Reading...
aws_glue_workflow.workflow: Refreshing state... [id=example]
aws_s3_bucket.cloudformation-bucket: Refreshing state... [id=e2e-test20230508111803867500000001]
data.aws_availability_zones.available: Read complete after 0s [id=eu-central-1]
data.aws_caller_identity.current: Read complete after 1s [id=792169733636]
module.stack-master.random_id.master-identifier: Refreshing state... [id=vCxhTZnn80c]
aws_s3_bucket_ownership_controls.cloudformation-bucket: Refreshing state... [id=e2e-test20230508111803867500000001]
aws_s3_object.cloudformation-object: Refreshing state... [id=SelectStarGlue.json]
random_id.master-identifier: Refreshing state... [id=r1OIm_fDEVg]
module.stack-master.aws_cloudformation_stack.stack-master: Refreshing state... [id=arn:aws:cloudformation:eu-central-1:792169733636:stack/selectstar-redshift-bc2c614d99e7f347/018fc1c0-ed92-11ed-b76b-0648d988f914]
null_resource.cluster: Refreshing state... [id=3364580033513400717]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  - destroy

Terraform will perform the following actions:

  # aws_glue_workflow.workflow will be destroyed
  - resource "aws_glue_workflow" "workflow" {
      - arn                    = "arn:aws:glue:eu-central-1:792169733636:workflow/example" -> null
      - default_run_properties = {} -> null
      - id                     = "example" -> null
      - max_concurrent_runs    = 0 -> null
      - name                   = "example" -> null
      - tags                   = {} -> null
      - tags_all               = {
          - "Component" = "test-e2e-glue"
          - "ManagedBy" = "Terraform"
        } -> null
    }

  # aws_s3_bucket.cloudformation-bucket will be destroyed
  - resource "aws_s3_bucket" "cloudformation-bucket" {
      - arn                         = "arn:aws:s3:::e2e-test20230508111803867500000001" -> null
      - bucket                      = "e2e-test20230508111803867500000001" -> null
      - bucket_domain_name          = "e2e-test20230508111803867500000001.s3.amazonaws.com" -> null
      - bucket_prefix               = "e2e-test" -> null
      - bucket_regional_domain_name = "e2e-test20230508111803867500000001.s3.eu-central-1.amazonaws.com" -> null
      - force_destroy               = false -> null
      - hosted_zone_id              = "Z21DNDUVLTQW6Q" -> null
      - id                          = "e2e-test20230508111803867500000001" -> null
      - object_lock_enabled         = false -> null
      - region                      = "eu-central-1" -> null
      - request_payer               = "BucketOwner" -> null
      - tags                        = {} -> null
      - tags_all                    = {
          - "Component" = "test-e2e-glue"
          - "ManagedBy" = "Terraform"
        } -> null

      - grant {
          - id          = "da65d21a2e02c62371679886cc8059f21491a3a90973cea226692c2f0897f6a1" -> null
          - permissions = [
              - "FULL_CONTROL",
            ] -> null
          - type        = "CanonicalUser" -> null
        }

      - server_side_encryption_configuration {
          - rule {
              - bucket_key_enabled = false -> null

              - apply_server_side_encryption_by_default {
                  - sse_algorithm = "AES256" -> null
                }
            }
        }

      - versioning {
          - enabled    = false -> null
          - mfa_delete = false -> null
        }
    }

  # aws_s3_bucket_ownership_controls.cloudformation-bucket will be destroyed
  - resource "aws_s3_bucket_ownership_controls" "cloudformation-bucket" {
      - bucket = "e2e-test20230508111803867500000001" -> null
      - id     = "e2e-test20230508111803867500000001" -> null

      - rule {
          - object_ownership = "BucketOwnerEnforced" -> null
        }
    }

  # aws_s3_object.cloudformation-object will be destroyed
  - resource "aws_s3_object" "cloudformation-object" {
      - acl                    = "private" -> null
      - bucket                 = "e2e-test20230508111803867500000001" -> null
      - bucket_key_enabled     = false -> null
      - content_type           = "binary/octet-stream" -> null
      - etag                   = "a9603d0c62d0bbcafc161df41a67f0ef" -> null
      - force_destroy          = false -> null
      - id                     = "SelectStarGlue.json" -> null
      - key                    = "SelectStarGlue.json" -> null
      - metadata               = {} -> null
      - server_side_encryption = "AES256" -> null
      - source                 = "./../SelectStarGlue.json" -> null
      - storage_class          = "STANDARD" -> null
      - tags                   = {} -> null
      - tags_all               = {
          - "Component" = "test-e2e-glue"
          - "ManagedBy" = "Terraform"
        } -> null
    }

  # null_resource.cluster will be destroyed
  - resource "null_resource" "cluster" {
      - id       = "3364580033513400717" -> null
      - triggers = {
          - "external_id" = "external-id"
          - "role_arn"    = "arn:aws:iam::792169733636:role/selectstar-redshift-bc2c614d99e7f-CrossAccountRole-9N0DOTGPMC6O"
        } -> null
    }

  # random_id.master-identifier will be destroyed
  - resource "random_id" "master-identifier" {
      - b64_std     = "r1OIm/fDEVg=" -> null
      - b64_url     = "r1OIm_fDEVg" -> null
      - byte_length = 8 -> null
      - dec         = "12633591583162437976" -> null
      - hex         = "af53889bf7c31158" -> null
      - id          = "r1OIm_fDEVg" -> null
      - keepers     = {
          - "etag" = "a9603d0c62d0bbcafc161df41a67f0ef"
        } -> null
    }

  # random_string.random will be destroyed
  - resource "random_string" "random" {
      - id          = "99fyshjxgjJrR5p47PRxKH8gOGXqLfF3" -> null
      - length      = 32 -> null
      - lower       = true -> null
      - min_lower   = 0 -> null
      - min_numeric = 0 -> null
      - min_special = 0 -> null
      - min_upper   = 0 -> null
      - number      = true -> null
      - numeric     = true -> null
      - result      = "99fyshjxgjJrR5p47PRxKH8gOGXqLfF3" -> null
      - special     = false -> null
      - upper       = true -> null
    }

  # module.stack-master.aws_cloudformation_stack.stack-master will be destroyed
  - resource "aws_cloudformation_stack" "stack-master" {
      - capabilities       = [
          - "CAPABILITY_IAM",
        ] -> null
      - disable_rollback   = false -> null
      - id                 = "arn:aws:cloudformation:eu-central-1:792169733636:stack/selectstar-redshift-bc2c614d99e7f347/018fc1c0-ed92-11ed-b76b-0648d988f914" -> null
      - name               = "selectstar-redshift-bc2c614d99e7f347" -> null
      - outputs            = {
          - "RoleArn" = "arn:aws:iam::792169733636:role/selectstar-redshift-bc2c614d99e7f-CrossAccountRole-9N0DOTGPMC6O"
        } -> null
      - parameters         = {
          - "ExternalId"   = "external-id"
          - "IamPrincipal" = "arn:aws:iam::792169733636:root"
        } -> null
      - tags               = {} -> null
      - tags_all           = {
          - "Component" = "test-e2e-glue"
          - "ManagedBy" = "Terraform"
        } -> null
      - template_body      = jsonencode(
            {
              - AWSTemplateFormatVersion = "2010-09-09"
              - Description              = "Stack to enable integration Select Star with Glue"
              - Metadata                 = {
                  - "AWS::CloudFormation::Interface" = {
                      - ParameterGroups = [
                          - {
                              - Label      = {
                                  - default = "Read-only. Do not change this."
                                }
                              - Parameters = [
                                  - "ExternalId",
                                  - "IamPrincipal",
                                ]
                            },
                        ]
                    }
                }
              - Outputs                  = {
                  - RoleArn = {
                      - Description = "The ARN value of the Cross-Account Role with IAM read-only permissions. Add this ARN value to Select Star."
                      - Value       = {
                          - "Fn::GetAtt" = [
                              - "CrossAccountRole",
                              - "Arn",
                            ]
                        }
                    }
                }
              - Parameters               = {
                  - ExternalId   = {
                      - Description = "The Select Star external ID to authenticate your AWS account. Do not change or share this."
                      - MinLength   = "1"
                      - Type        = "String"
                    }
                  - IamPrincipal = {
                      - Description = "The Select Star IAM principal which has permission to your AWS account. Do not change this."
                      - MinLength   = "1"
                      - Type        = "String"
                    }
                }
              - Resources                = {
                  - CrossAccountRole       = {
                      - Properties = {
                          - AssumeRolePolicyDocument = {
                              - Statement = [
                                  - {
                                      - Action    = [
                                          - "sts:AssumeRole",
                                        ]
                                      - Condition = {
                                          - StringEquals = {
                                              - "sts:ExternalId" = {
                                                  - Ref = "ExternalId"
                                                }
                                            }
                                        }
                                      - Effect    = "Allow"
                                      - Principal = {
                                          - AWS = {
                                              - Ref = "IamPrincipal"
                                            }
                                        }
                                    },
                                ]
                              - Version   = "2012-10-17"
                            }
                        }
                      - Type       = "AWS::IAM::Role"
                    }
                  - CrossAccountRolePolicy = {
                      - Properties = {
                          - PolicyDocument = {
                              - Statement = [
                                  - {
                                      - Action   = [
                                          - "glue:GetTables",
                                          - "glue:GetDatabases",
                                        ]
                                      - Effect   = "Allow"
                                      - Resource = [
                                          - {
                                              - "Fn::Sub" = "arn:aws:glue:${AWS::Region}:${AWS::AccountId}:catalog"
                                            },
                                          - {
                                              - "Fn::Sub" = "arn:aws:glue:${AWS::Region}:${AWS::AccountId}:database/*"
                                            },
                                          - {
                                              - "Fn::Sub" = "arn:aws:glue:${AWS::Region}:${AWS::AccountId}:table/*"
                                            },
                                        ]
                                    },
                                ]
                              - Version   = "2012-10-17"
                            }
                          - PolicyName     = "EnableSelectStar"
                          - Roles          = [
                              - {
                                  - Ref = "CrossAccountRole"
                                },
                            ]
                        }
                      - Type       = "AWS::IAM::Policy"
                    }
                }
            }
        ) -> null
      - template_url       = "https://e2e-test20230508111803867500000001.s3.eu-central-1.amazonaws.com/SelectStarGlue.json" -> null
      - timeout_in_minutes = 0 -> null
    }

  # module.stack-master.random_id.master-identifier will be destroyed
  - resource "random_id" "master-identifier" {
      - b64_std     = "vCxhTZnn80c=" -> null
      - b64_url     = "vCxhTZnn80c" -> null
      - byte_length = 8 -> null
      - dec         = "13559319564028212039" -> null
      - hex         = "bc2c614d99e7f347" -> null
      - id          = "vCxhTZnn80c" -> null
      - keepers     = {
          - "ExternalId"   = "external-id"
          - "IamPrincipal" = "arn:aws:iam::792169733636:root"
          - "prefix"       = "selectstar-redshift"
        } -> null
    }

Plan: 0 to add, 0 to change, 9 to destroy.

Changes to Outputs:
  - role_arn = "arn:aws:iam::792169733636:role/selectstar-redshift-bc2c614d99e7f-CrossAccountRole-9N0DOTGPMC6O" -> null

Do you really want to destroy all resources?
  Terraform will destroy all your managed infrastructure, as shown above.
  There is no undo. Only 'yes' will be accepted to confirm.

  Enter a value: yes

random_id.master-identifier: Destroying... [id=r1OIm_fDEVg]
random_string.random: Destroying... [id=99fyshjxgjJrR5p47PRxKH8gOGXqLfF3]
random_id.master-identifier: Destruction complete after 0s
random_string.random: Destruction complete after 0s
null_resource.cluster: Destroying... [id=3364580033513400717]
null_resource.cluster: Destruction complete after 0s
aws_s3_bucket_ownership_controls.cloudformation-bucket: Destroying... [id=e2e-test20230508111803867500000001]
aws_glue_workflow.workflow: Destroying... [id=example]
module.stack-master.aws_cloudformation_stack.stack-master: Destroying... [id=arn:aws:cloudformation:eu-central-1:792169733636:stack/selectstar-redshift-bc2c614d99e7f347/018fc1c0-ed92-11ed-b76b-0648d988f914]
aws_glue_workflow.workflow: Destruction complete after 0s
aws_s3_bucket_ownership_controls.cloudformation-bucket: Destruction complete after 0s
module.stack-master.aws_cloudformation_stack.stack-master: Still destroying... [id=arn:aws:cloudformation:eu-central-1:792...7/018fc1c0-ed92-11ed-b76b-0648d988f914, 10s elapsed]
module.stack-master.aws_cloudformation_stack.stack-master: Destruction complete after 11s
aws_s3_object.cloudformation-object: Destroying... [id=SelectStarGlue.json]
module.stack-master.random_id.master-identifier: Destroying... [id=vCxhTZnn80c]
module.stack-master.random_id.master-identifier: Destruction complete after 0s
aws_s3_object.cloudformation-object: Destruction complete after 0s
aws_s3_bucket.cloudformation-bucket: Destroying... [id=e2e-test20230508111803867500000001]
aws_s3_bucket.cloudformation-bucket: Destruction complete after 0s

Destroy complete! Resources: 9 destroyed.
```
## Type of change

-   [ ] Refactor (non-breaking change that improves codebase).
-   [ ] Bug fix (non-breaking change that fixes an issue).
-   [ ] New feature (non-breaking change that adds functionality).
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
-   [ ] Chore (none of the above, but still important)

## Related tickets

-   Story sc-52284

## Checklists

-   [ ] No backend changes needed.
-   [ ] All related backend changes are ready.
    -   [links to related PRs]
