### PR TITLE
redshift: Retain AWS S3 bucket policy to align to AWS S3 bucket lifetime [sc-53374]

### DIFF
--- a/redshift/SelectStarRedshift.json
+++ b/redshift/SelectStarRedshift.json
@@ -156,6 +156,7 @@
         "LoggingBucketPolicy": {
             "Type": "AWS::S3::BucketPolicy",
             "Condition": "CreateS3Bucket",
+            "DeletionPolicy": "Retain",
             "Properties": {
                 "Bucket": {
                     "Ref": "LoggingBucket"


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change. -->

We delete AWS S3 bucket policy for AWS S3 bucket, but we should not do that.

During provisioning, we create an S3 bucket, an S3 bucket policy to allow writing to Redshift, then configure Redshift to send logs to that S3 bucket.

During deprovisioning we:
* we keep the S3 bucket because this is customer data and they may have started using it for their own purposes
* we keep Redshift's configurations because he may have started using them for his own purposes

However, we remove the AWS S3 bucket policy for writing via Redshift to AWS S3, so the AWS Redshift configuration is corrupted because Redshift loses the ability to write logs to AWS S3.

During the re-provisioning, we do not change the Redshift configuration, because we see that it is set (although it is broken) and we give ourselves permissions to the old bucket. However, it the bucket there are no new queries because writing logs are broken.

To avoid that we need to stop removing AWS S3 bucket policy, so align the lifetime of AWS S3 bucket policy to the lifetime of AWS S3 bucket.

## How to reproduce/test?

<!-- Please please provide links or steps which help to check your submission. You can also put any evidence "works for me" here. --> 

## Type of change

-   [ ] Refactor (non-breaking change that improves codebase).
-   [ ] Bug fix (non-breaking change that fixes an issue).
-   [ ] New feature (non-breaking change that adds functionality).
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
-   [ ] Chore (none of the above, but still important)

## Related tickets

-   Story sc-53374

## Checklists

-   [ ] No backend changes needed.
-   [ ] All related backend changes are ready.
    -   [links to related PRs]
