### PR TITLE
fix(aurora): 🐛 fix parameters for Terraform module [sc-71823]

### DIFF
--- a/aurora-postgresql/terraform/main.tf
+++ b/aurora-postgresql/terraform/main.tf
@@ -1,6 +1,6 @@
 resource "random_id" "db-identifier" {
   keepers = {
-    prefix = var.name_prefix
+    prefix     = var.name_prefix
     identifier = var.db_identifier
   }
   byte_length = 8
@@ -16,9 +16,9 @@ resource "aws_cloudformation_stack" "rds-stack" {
   disable_rollback = var.disable_rollback
 
   parameters = {
-    ServerName                = data.aws_rds_cluster.rds.cluster_identifier
-    ExternalId                = var.external_id
-    IamPrincipal              = var.iam_principal
+    ClusterName  = data.aws_rds_cluster.rds.cluster_identifier
+    ExternalId   = var.external_id
+    IamPrincipal = var.iam_principal
   }
 
   capabilities = ["CAPABILITY_IAM"]


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change. -->

The customer reported a mismatch between the parameter expected by the AWS CloudFormation template for AWS Aurora PostgreSQL and the parameter passed by the Terraform module for AWS Aurora PostgreSQL. 

The issue was introduced by applying review comments in https://github.com/selectstar/cloudformation-templates/commit/1b3b1908af81c396c6be41848d13b26c296b249c . 

The expected parameter by AWS CloudFormation is defined here: https://github.com/selectstar/cloudformation-templates/blob/028db63181614dada09e9ffaa7cb533a01af0e0f/aurora-postgresql/SelectStarAuroraPostgreSQL.json#L5 

I considered renaming the parameter to `ServerName`, but that would require synchronization on the FE side, and the current solution is just as good (if not better).

## How to reproduce/test?

<!-- Please please provide links or steps which help to check your submission. You can also put any evidence "works for me" here. --> 

Execute e2e for AWS Aurora, which consumed the Terraform module. 

## Type of change

-   [ ] Refactor (non-breaking change that improves codebase).
-   [ ] Bug fix (non-breaking change that fixes an issue).
-   [ ] New feature (non-breaking change that adds functionality).
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
-   [ ] Chore (none of the above, but still important)

## Related tickets

-   Story sc-XXXXX

## Checklists

-   [ ] No backend changes needed.
-   [ ] All related backend changes are ready.
    -   [links to related PRs]
