### PR TITLE
feat: 😸 improve compliance in redshift template [sc-82761]

### DIFF
--- a/redshift/SelectStarRedshift.json
+++ b/redshift/SelectStarRedshift.json
@@ -136,7 +136,7 @@
                     "default": "Restart Cluster (if necessary to apply changes)"
                 },
                 "ConfigureNetwork": {
-                    "default": "Ignore public access checking"
+                    "default": "Configure network access"
                 }
             }
         }

--- a/redshift/SelectStarRedshift.json
+++ b/redshift/SelectStarRedshift.json
@@ -448,7 +448,9 @@
                                 "redshift:ModifyClusterParameterGroup",
                                 "redshift:ModifyCluster",
                                 "redshift:RebootCluster",
-                                "redshift-data:ExecuteStatement"
+                                "redshift:GetClusterCredentials",
+                                "redshift-data:ExecuteStatement",
+                                "redshift-data:ListDatabases"
                             ],
                             "Resource": [
                                 {

--- a/redshift/SelectStarRedshift.json
+++ b/redshift/SelectStarRedshift.json
@@ -68,6 +68,15 @@
             ],
             "Description": "If true and logging changes made then the Redshift cluster can be restarted to apply changes. It is recommended to set the value \"true\"."
         },
+        "ConfigureNetwork": {
+            "Type": "String",
+            "Default": "false",
+            "AllowedValues": [
+                "true",
+                "false"
+            ],
+            "Description": "The default AWS Redshfit configuration requires the instance to be public to access metadata. If true then we verify that the Redshift instance is public and configure VPC security group rules to allow access. Do not change this parameter unless you have been specifically instructed otherwise by the support team.\n\nTo connect to an private instance, contact the support team to select the optimal connectivity solution."
+        },
         "SentryDsn": {
             "Description": "URL for reporting any errors in provisioning execution. Don't change it unless you really know what you are doing.",
             "Type": "String",
@@ -94,7 +103,8 @@
                     },
                     "Parameters": [
                         "ConfigureS3Logging",
-                        "ConfigureS3LoggingRestart"
+                        "ConfigureS3LoggingRestart",
+                        "ConfigureNetwork"
                     ]
                 },
                 {
@@ -124,6 +134,9 @@
                 },
                 "ConfigureS3LoggingRestart": {
                     "default": "Restart Cluster (if necessary to apply changes)"
+                },
+                "ConfigureNetwork": {
+                    "default": "Ignore public access checking"
                 }
             }
         }
@@ -133,6 +146,14 @@
             "Fn::Equals": [
                 {
                     "Ref": "ConfigureS3Logging"
+                },
+                "true"
+            ]
+        },
+        "CreateVPCRules": {
+            "Fn::Equals": [
+                {
+                    "Ref": "ConfigureNetwork"
                 },
                 "true"
             ]
@@ -417,8 +438,17 @@
                         {
                             "Effect": "Allow",
                             "Action": [
-                                "redshift:*",
-                                "redshift-data:*"
+                                "redshift:DescribeClusters",
+                                "redshift:DescribeLoggingStatus",
+                                "redshift:DescribeClusterParameters",
+                                "redshift:DescribeClusterParameterGroups",
+                                "redshift:CreateClusterParameterGroup",
+                                "redshift:EnableLogging",
+                                "redshift:ModifyClusterIamRoles",
+                                "redshift:ModifyClusterParameterGroup",
+                                "redshift:ModifyCluster",
+                                "redshift:RebootCluster",
+                                "redshift-data:ExecuteStatement"
                             ],
                             "Resource": [
                                 {
@@ -598,6 +628,9 @@
                 },
                 "ConfigureS3LoggingRestart": {
                     "Ref": "ConfigureS3LoggingRestart"
+                },
+                "ConfigureNetwork": {
+                    "Ref": "ConfigureNetwork"
                 }
             }
         },
@@ -692,6 +725,7 @@
         },
         "InboundPrimaryRule": {
             "Type": "AWS::EC2::SecurityGroupIngress",
+            "Condition": "CreateVPCRules",
             "Properties": {
                 "IpProtocol": "tcp",
                 "Description": {
@@ -722,6 +756,7 @@
         },
         "InboundSecondaryRule": {
             "Type": "AWS::EC2::SecurityGroupIngress",
+            "Condition": "CreateVPCRules",
             "Properties": {
                 "IpProtocol": "tcp",
                 "Description": {

--- a/redshift/e2e/main.tf
+++ b/redshift/e2e/main.tf
@@ -8,6 +8,11 @@ variable "name" {
   type    = string
 }
 
+variable "configure_network" { ## Flag for test case
+  default = true
+  type = bool
+}
+
 data "aws_availability_zones" "available" {}
 
 data "aws_caller_identity" "current" {}
@@ -61,7 +66,7 @@ resource "aws_redshift_cluster" "e2e" {
   automated_snapshot_retention_period = 0
   skip_final_snapshot                 = true
   cluster_subnet_group_name           = aws_redshift_subnet_group.subnet_group.name
-
+  publicly_accessible                 = var.configure_network
   lifecycle {
     # provision.py add a new ingress rules what we wanna ignore here
     ignore_changes = [
@@ -119,7 +124,7 @@ module "stack-master" {
   provisioning_database = aws_redshift_cluster.e2e.database_name
   external_id           = "X"
   iam_principal         = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
-
+  configure_network     = var.configure_network
   template_url = local.template_url
 
   depends_on = [

--- a/redshift/provision.py
+++ b/redshift/provision.py
@@ -118,7 +118,7 @@ def ensure_cluster_state(cluster):
     logger.info("Publicly accessible status is '%s'. ", instance["PubliclyAccessible"])
 
 
-def ensure_valid_cluster(cluster):
+def ensure_valid_cluster(cluster, ConfigureNetwork):
     try:
         instances = redshift_client.describe_clusters(ClusterIdentifier=cluster)[
             "Clusters"
@@ -130,7 +130,7 @@ def ensure_valid_cluster(cluster):
             ) from err
         raise err
     instance = instances[0]
-    if not instance["PubliclyAccessible"]:
+    if not instance["PubliclyAccessible"] and ConfigureNetwork:
         raise DataException(
             "Cluster must be publicly available. Update the cluster configurations (https://aws.amazon.com/premiumsupport/knowledge-center/redshift-cluster-private-public/) and try again."
         )
@@ -210,7 +210,9 @@ def create_cluster_parameter_group(parameter_group, prefix):
                 Description="Created by CloudFormation on provisioning Select Star",
             )
             return name
-        except redshift_client.exceptions.ClusterParameterGroupAlreadyExistsFault as err:
+        except (
+            redshift_client.exceptions.ClusterParameterGroupAlreadyExistsFault
+        ) as err:
             logger.warn(f"API call failed ({err}); continue with new suffix...")
             continue
     raise DataException(
@@ -355,6 +357,7 @@ def handler(event, context):
         dbUser = properties["DbUser"]
         configureS3Logging = properties["ConfigureS3Logging"] == "true"
         configureS3LoggingRestart = properties["ConfigureS3LoggingRestart"] == "true"
+        ConfigureNetwork = properties["ConfigureNetwork"] == "true"
 
         ensure_cluster_state(cluster)
 
@@ -390,7 +393,9 @@ def handler(event, context):
                 event, context, cfnresponse.SUCCESS, {"Data": "Delete complete"}
             )
         else:
-            security_group_id, endpoint_port = ensure_valid_cluster(cluster)
+            security_group_id, endpoint_port = ensure_valid_cluster(
+                cluster, ConfigureNetwork
+            )
             logger.info("Ćluster validated successfully")
 
             ensure_iam_role(cluster, role)

--- a/redshift/provision.py
+++ b/redshift/provision.py
@@ -328,7 +328,7 @@ def ensure_cluster_restarted(cluster, configureS3LoggingRestart):
 
 
 SKIP_DB = [
-    "awsdatacatalog"
+    "awsdatacatalog",
     # database for AWS Glue Data Catalog is a preview feature - https://app.shortcut.com/select-star/story/57903
     # contact sales if you need to activate AWS Glue Data Catalog support
 ]

--- a/redshift/terraform/main.tf
+++ b/redshift/terraform/main.tf
@@ -26,6 +26,7 @@ resource "aws_cloudformation_stack" "stack-master" {
     CidrIpSecondary           = "3.20.56.105/32"
     ConfigureS3Logging        = var.configure_s3_logging
     ConfigureS3LoggingRestart = var.configure_s3_logging_restart
+    ConfigureNetwork          = var.configure_network
     SentryDsn                 = "https://14d65555628a4b6f84fcb83ef1511778@o407979.ingest.sentry.io/6639248"
   }
 

--- a/redshift/terraform/variables.tf
+++ b/redshift/terraform/variables.tf
@@ -56,6 +56,12 @@ variable "configure_s3_logging_restart" {
   description = "If true and logging changes made then the Redshift cluster can be restarted to apply changes. It is recommended to set the value \"true\"."
 }
 
+variable "configure_network" {
+  type = bool
+  default = true
+  description = "The default AWS Redshfit configuration requires the instance to be public to access metadata. If true then we verify that the Redshift instance is public and configure VPC security group rules to allow access. Do not change this parameter unless you have been specifically instructed otherwise by the support team.\n\nTo connect to an private instance, contact the support team to select the optimal connectivity solution."
+}
+
 variable "template_url" {
   type        = string
   default     = "https://select-star-production-cloudformation.s3.us-east-2.amazonaws.com/redshift/SelectStarRedshift.json"


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX19YfWL9yAXPtVfXhiOSBufhFlsymDzIaI%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=dMOTVwb)
## Description

<!-- Please include a summary of the change. -->

This PR has two changes:

* limits permissions granted to `LambdaRolePolicy` - code inspection has previously been considered sufficient, but some environments have automatic scanners that flag such policies without this context
* enables provisioning of Redshift clusters without public access - adding such a data source will still most likely fail to be added on the platform, unless AWS PrivateLink / AWS NLB is used, which still requires manual process later one

## How to reproduce/test?

<!-- Please please provide links or steps which help to check your submission. You can also put any evidence "works for me" here. --> 

## Type of change

-   [ ] Refactor (non-breaking change that improves codebase).
-   [ ] Bug fix (non-breaking change that fixes an issue).
-   [ ] New feature (non-breaking change that adds functionality).
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
-   [ ] Chore (none of the above, but still important)

## Related tickets

-   Story sc-XXXXX

## Checklists

-   [ ] No backend changes needed.
-   [ ] All related backend changes are ready.
    -   [links to related PRs]
