### PR TITLE
feat: 😸 enable CW logs in Redshift [sc-89969]

### DIFF
--- a/redshift/SelectStarRedshift.json
+++ b/redshift/SelectStarRedshift.json
@@ -58,7 +58,7 @@
                 "true",
                 "false"
             ],
-            "Description": "If true and S3 logging disabled then the Redshift cluster configuration can be changed to enable S3 logging. It is recommended to set the value \"true\"."
+            "Description": "If true and logging disabled then the Redshift cluster configuration can be changed to enable S3 logging. It is recommended to set the value \"true\"."
         },
         "ConfigureS3LoggingRestart": {
             "Type": "String",
@@ -363,6 +363,28 @@
                                     ]
                                 }
                             ]
+                        },
+                        {
+                            "Action": [
+                                "logs:Get*",
+                                "logs:List*",
+                                "logs:StartQuery",
+                                "logs:StopQuery",
+                                "logs:Describe*",
+                                "logs:FilterLogEvents"
+                            ],
+                            "Effect": "Allow",
+                            "Resource": {
+                                "Fn::Sub": "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/redshift/cluster/${Cluster}/*"
+                            }
+                        },
+                        {
+                            "Action": [
+                                "logs:GetQueryResults",
+                                "logs:DescribeLogGroups"
+                            ],
+                            "Effect": "Allow",
+                            "Resource": "arn:aws:logs:*:*:log-group::log-stream:"
                         }
                     ]
                 },
@@ -797,15 +819,6 @@
                 ]
             },
             "Description": "The ARN value of the Cross-Account Role with IAM read-only permissions. Add this ARN value to Select Star."
-        },
-        "LoggingBucket": {
-            "Value": {
-                "Fn::GetAtt": [
-                    "LambdaProvision",
-                    "LoggingBucket"
-                ]
-            },
-            "Description": "The bucket name which stores Redshift logs."
         }
     }
 }


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change. -->

That PR introduces reading logs from CloudWatch in Redshift.

If log export is not activated, we activate log export to AWS S3 (as so far). Consumers can set AWS CW themselves in advance or manually switch to AWS CW anytime.

Suppose log export to AWS CW is activated. In that case, we get additional rights to AWS S3 "dummy-bucket", because it is difficult to do such dynamic policy generation in AWS CloudFormation (it could be done using Custom Resource, but it could be more prone to failures).

If the log is exported to AWS S3 - we get permissions to AWS CW, which we will be able to use in the future, and permission to read the logging bucket.

## How to reproduce/test?

<!-- Please please provide links or steps which help to check your submission. You can also put any evidence "works for me" here. --> 

## Type of change

-   [ ] Refactor (non-breaking change that improves codebase).
-   [ ] Bug fix (non-breaking change that fixes an issue).
-   [ ] New feature (non-breaking change that adds functionality).
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
-   [ ] Chore (none of the above, but still important)

## Related tickets

-   Story sc-XXXXX

## Checklists

-   [ ] No backend changes needed.
-   [ ] All related backend changes are ready.
    -   [links to related PRs]
