### PR TITLE
fix(redshift): 🐛 make LoggingBucket truly optional [sc-89969]

### DIFF
--- a/redshift/SelectStarRedshift.json
+++ b/redshift/SelectStarRedshift.json
@@ -532,7 +532,24 @@
                                     ]
                                 }
                             ]
-                        },
+                        }
+                    ]
+                },
+                "PolicyName": "EnableSelectStarProvisioning",
+                "Roles": [
+                    {
+                        "Ref": "LambdaRole"
+                    }
+                ]
+            }
+        },
+        "LambdaRoleBucketPolicy": {
+            "Type": "AWS::IAM::Policy",
+            "Condition": "CreateS3Bucket",
+            "Properties": {
+                "PolicyDocument": {
+                    "Version": "2012-10-17",
+                    "Statement": [
                         {
                             "Effect": "Allow",
                             "Action": "*",
@@ -564,7 +581,7 @@
                         }
                     ]
                 },
-                "PolicyName": "EnableSelectStarProvisioning",
+                "PolicyName": "EnableSelectStarBucket",
                 "Roles": [
                     {
                         "Ref": "LambdaRole"

--- a/redshift/e2e/main.tf
+++ b/redshift/e2e/main.tf
@@ -10,7 +10,7 @@ variable "name" {
 
 variable "configure_network" { ## Flag for test case
   default = true
-  type = bool
+  type    = bool
 }
 
 data "aws_availability_zones" "available" {}
@@ -125,10 +125,29 @@ module "stack-master" {
   external_id           = "X"
   iam_principal         = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
   configure_network     = var.configure_network
-  template_url = local.template_url
+  template_url          = local.template_url
 
   depends_on = [
     aws_redshift_cluster.e2e
+  ]
+}
+
+module "stack-configurationless" {
+  source = "../terraform"
+
+  cluster_identifier           = aws_redshift_cluster.e2e.cluster_identifier
+  provisioning_user            = aws_redshift_cluster.e2e.master_username
+  provisioning_database        = aws_redshift_cluster.e2e.database_name
+  # for already configured cluster, we may skip the logging configuration
+  configure_s3_logging         = false
+  configure_s3_logging_restart = false
+  external_id                  = "X"
+  iam_principal                = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+  configure_network            = var.configure_network
+  template_url                 = local.template_url
+
+  depends_on = [
+    module.stack-master
   ]
 }
 

--- a/redshift/provision.py
+++ b/redshift/provision.py
@@ -327,6 +327,7 @@ def ensure_cluster_restarted(cluster, configureS3LoggingRestart):
 
 SKIP_DB = [
     "awsdatacatalog",
+    "sys:internal",
     # database for AWS Glue Data Catalog is a preview feature - https://app.shortcut.com/select-star/story/57903
     # contact sales if you need to activate AWS Glue Data Catalog support
 ]


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change. -->

Fixes issue reported on Shortcut: 
![image](https://github.com/user-attachments/assets/fa9f8682-1f1e-4016-824b-397a08499919)

When enabling configure logging as optional, the S3 bucket was skipped to create, but we still tried to reference it.

To enable that:

* resource IAM policy `LambdaRolePolicy` was split into two resources:
   * resource IAM policy `LambdaRolePolicy` – always created, keep a shared subset of policies of previous `LambdaRolePolicy`
   *  resource IAM policy `LambdaRoleBucketPolicy` – created codintionally, have subset of policies of previous `LambdaRolePolicy` about accessing S3 bucket

## How to reproduce/test?

<!-- Please please provide links or steps which help to check your submission. You can also put any evidence "works for me" here. --> 

Added e2e test

## Type of change

-   [ ] Refactor (non-breaking change that improves codebase).
-   [ ] Bug fix (non-breaking change that fixes an issue).
-   [ ] New feature (non-breaking change that adds functionality).
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
-   [ ] Chore (none of the above, but still important)

## Related tickets

-   Story sc-XXXXX

## Checklists

-   [ ] No backend changes needed.
-   [ ] All related backend changes are ready.
    -   [links to related PRs]
